### PR TITLE
ci: lint commit messages

### DIFF
--- a/.github/workflows/lint_commit_message.yml
+++ b/.github/workflows/lint_commit_message.yml
@@ -1,0 +1,16 @@
+name: Lint commit message
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint-commit-message:
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - run: ./scripts/lint_commit_message.sh "${{ github.event.head_commit.message }}"
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # node-gateway
 Blockchain node gateway.
+
+# Development
+## Commit message linting
+CI enforces that commit messages meet the [conventional commit format](https://conventionalcommits.org). For convenience of local development, there's a commit-msg Git hook that verifies if the commit message is valid. To use it, create a symlink:
+```
+ln -s $PWD/scripts/git_hooks/* .git/hooks
+```

--- a/scripts/git_hooks/commit-msg
+++ b/scripts/git_hooks/commit-msg
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+BRed="\033[1;31m" # Red
+
+COMMIT_MSG_FILE=$1
+COMMIT_MESSAGE="$(cat $COMMIT_MSG_FILE)"
+
+./scripts/lint_commit_message.sh "$COMMIT_MESSAGE" && RETURN_CODE=$? || RETURN_CODE=$?
+
+if [[ $RETURN_CODE -eq 1 ]]
+then
+    printf "${BRed}Commit failed.\n"
+    exit 1
+fi

--- a/scripts/lint_commit_message.sh
+++ b/scripts/lint_commit_message.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+VALID_COMMIT_REGEX=""
+
+ALLOWED_TYPES=("build" "chore" "ci" "docs" "feat" "fix" "perf" "refactor" "revert" "style" "test")
+for TYPE in ${ALLOWED_TYPES[@]}; do
+  VALID_COMMIT_REGEX="$VALID_COMMIT_REGEX$TYPE(\([a-zA-Z0-9 ]+\)){0,1}(!){0,1}: |"
+done
+
+# Remove trailing pipe.
+VALID_COMMIT_REGEX=$(echo $VALID_COMMIT_REGEX | rev | cut -c2- | rev)
+# Add parens.
+VALID_COMMIT_REGEX="(${VALID_COMMIT_REGEX})"
+
+
+COMMIT_MESSAGE=$1
+if [[ $COMMIT_MESSAGE =~ $VALID_COMMIT_REGEX ]]
+then
+  exit 0
+else
+  echo "Commit message does follow the conventional commit format."
+  exit 1
+fi


### PR DESCRIPTION
It doesn't make sense to lint the commit messages in the PR because the squash merge commit name can be specified when squash merging. Instead, we'll rely on the local git `commit-msg` hook and linting commits on `main`.