### PR TITLE
feat: pass through invalid JSON RPC messages, handle empty JSON RPC responses

### DIFF
--- a/internal/mocks/EthClient.go
+++ b/internal/mocks/EthClient.go
@@ -3,10 +3,9 @@
 package mocks
 
 import (
-	context "context"
 	big "math/big"
 
-	client "github.com/satsuma-data/node-gateway/internal/client"
+	context "context"
 
 	ethereum "github.com/ethereum/go-ethereum"
 
@@ -85,20 +84,6 @@ func (_m *EthClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.Head
 	}
 
 	return r0, r1
-}
-
-// SubscribeNewHeadWrapper provides a mock function with given fields: ctx, handler
-func (_m *EthClient) SubscribeNewHeadWrapper(ctx context.Context, handler *client.NewHeadHandler) error {
-	ret := _m.Called(ctx, handler)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *client.NewHeadHandler) error); ok {
-		r0 = rf(ctx, handler)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
 }
 
 // SyncProgress provides a mock function with given fields: ctx

--- a/internal/mocks/Router.go
+++ b/internal/mocks/Router.go
@@ -16,14 +16,16 @@ type Router struct {
 }
 
 // Route provides a mock function with given fields: requestBody
-func (_m *Router) Route(requestBody jsonrpc.RequestBody) (jsonrpc.ResponseBody, *http.Response, error) {
+func (_m *Router) Route(requestBody jsonrpc.RequestBody) (*jsonrpc.ResponseBody, *http.Response, error) {
 	ret := _m.Called(requestBody)
 
-	var r0 jsonrpc.ResponseBody
-	if rf, ok := ret.Get(0).(func(jsonrpc.RequestBody) jsonrpc.ResponseBody); ok {
+	var r0 *jsonrpc.ResponseBody
+	if rf, ok := ret.Get(0).(func(jsonrpc.RequestBody) *jsonrpc.ResponseBody); ok {
 		r0 = rf(requestBody)
 	} else {
-		r0 = ret.Get(0).(jsonrpc.ResponseBody)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*jsonrpc.ResponseBody)
+		}
 	}
 
 	var r1 *http.Response

--- a/internal/router_test.go
+++ b/internal/router_test.go
@@ -34,7 +34,7 @@ func TestRouter_NoHealthyUpstreams(t *testing.T) {
 	jsonResp, httpResp, err := router.Route(jsonrpc.RequestBody{})
 	defer httpResp.Body.Close()
 
-	assert.Equal(t, jsonrpc.ResponseBody{}, jsonResp)
+	assert.Nil(t, jsonResp)
 	assert.Equal(t, 503, httpResp.StatusCode)
 	assert.Equal(t, "No healthy upstream", readyBody(httpResp.Body))
 	assert.Nil(t, err)


### PR DESCRIPTION
# Description
- Handles empty JSON RPC responses 
- Log and pass through invalid json rpc msgs
- Better logging when something can't be deserialized

# Background
- Router was choking on deserializing an empty response
```
2022-08-17T03:18:26.937Z	ERROR	internal/router.go:93	Could not deserialize response	{"request": {"jsonrpc":"2.0","method":"web3_clientVersion"}, "response": "&{200 OK 200 HTTP/1.1 1 1 map[Content-Type:[application/json] Date:[Wed, 17 Aug 2022 03:18:26 GMT]] 0xc0002ac020 -1 [] false true map[] 0xc00011a400 <nil>}", "error": "EOF"}
```
- (In this case I think the client is sending a bad request. They should be including the ID in the request.)
- Empty JSON RPC responses are valid as per [spec](https://www.jsonrpc.org/specification#notification)

# Testing
Response when hitting geth directly:
```
[ec2-user@ip-172-31-4-71 docker]$ curl -vv -X POST --data '{"jsonrpc":"2.0","method":"web3_clientVersion"}' --header 'Content-Type: application/json' 35.173.249.208:8545
...
...
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Wed, 17 Aug 2022 14:34:20 GMT
< Content-Length: 0
```

Now when hitting gateway:
```

[ec2-user@ip-172-31-4-71 docker]$ curl -vv -X POST --data '{"jsonrpc":"2.0","method":"web3_clientVersion"}' --header 'Content-Type: application/json' localhost:8080
...
...
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Wed, 17 Aug 2022 14:37:18 GMT
< Content-Length: 0
<
```

Erigon returns a new line character in their response:
```
2022-08-17T14:39:33.992Z	ERROR	internal/router.go:98	Could not deserialize response	{"request": {"jsonrpc":"2.0","method":"web3_clientVersion"}, "response": "&{200 OK 200 HTTP/1.1 1 1 map[Content-Type:[application/json] Date:[Wed, 17 Aug 2022 14:39:33 GMT] Vary:[Origin]] 0xc000024620 -1 [] false true map[] 0xc00029f900 <nil>}", "error": "decode error: EOF, content: \n"}
...
...
...
[ec2-user@ip-172-31-4-71 docker]$ curl  -X POST --data '{"jsonrpc":"2.0","method":"web3_clientVersion"}' --header 'Content-Type: application/json' localhost:8080
{"error":{"message":"Request could not be routed, err: decode error: EOF, content: \n","code":-32000},"jsonrpc":"2.0","id":0}
```

The spec suggests that no response should be returned 🤔 
```
A Notification is a Request object without an "id" member. A Request object that is a Notification signifies the Client's lack of interest in the corresponding Response object, and as such no Response object needs to be returned to the client. The Server MUST NOT reply to a Notification, including those that are within a batch request.

Notifications are not confirmable by definition, since they do not have a Response object to be returned. As such, the Client would not be aware of any errors (like e.g. "Invalid params","Internal error").
```

