### PR TITLE
feat:  Upstream groups and priority load balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ See the [sample config](/configs/config.sample.yml).
 ## Features
 
 - Round-robin load balancing for EVM-based JSON RPCs.
-- Health checks for block height, uptime, and response time.
+- Health checks for block height, peer count, and sync status.
 - Automated routing to nodes at max block height for data consistency.
+- Node grouping which supports priority load balancing (e.g. primary/fallback).
 
 #### 🔮 Roadmap
 
@@ -53,7 +54,7 @@ See the [sample config](/configs/config.sample.yml).
 - Caching.
 - WebSockets.
 - Additional data consistency measures (broadcasting to multiple nodes, uncled blocks, etc).
-- Additional routing strategies (archive/full node, primary/fallback, etc).
+- Additional routing strategies (archive/full node, etc).
 - Filter support (`eth_newBlockFilter`, `eth_newFilter`, and `eth_newPendingTransactionFilter`).
 
 Interested in a specific feature? Join our [Discord community]() to let us know.

--- a/configs/config.sample.yml
+++ b/configs/config.sample.yml
@@ -1,6 +1,24 @@
 global:
   port: 8080
 
+# (Optional) List of upstream node groups.
+# If defined, all upstreams must define group membership via the `group` field.
+groups:
+  # Each group must have the following keys
+  # 
+  # id - Unique identifer for the group.
+  # priority - Defines the routing priority for nodes in the group.
+  #            The lower the number, the higher the priority. 
+  #            Priority routing works by identifying the highest priority group with at least 
+  #              one healthy upstream. For example, if the highest priority group doesn't have any healthy upstreams, 
+  #              the gateway will look at the group at the next priority level to see if it has any healthy upstreams. It will continue 
+  #              until it finds a group that has at least one healthy upstream. If there are multiple upstreams in that group, requests are
+  #              spread across the upstreams in a round-robin fashion.
+  - id: primary
+    priority: 0
+  - id: fallback
+    priority: 1
+  
 # List of upstream node RPCs.
 upstreams:
   # Each upstream can have the following keys:
@@ -15,20 +33,20 @@ upstreams:
   #     it quickly updates the gateway with the latest block height. If this
   #     setting is undefined, the gateway will attempt to subscribe to new
   #     heads if the upstream supports it.
+  - id: my-node
+    httpURL: "http://12.57.207.168:8545"
+    wsURL: "wss://12.57.207.168:8546"
+    group: primary
   - id: infura-eth
     httpURL: "https://mainnet.infura.io/v3/${INFURA_API_KEY}"
     wsURL: "wss://mainnet.infura.io/ws/v3/${INFURA_API_KEY}"
     basicAuth:
       username: ~
       password: ${INFURA_API_KEY_SECRET}
+    group: fallback
   - id: alchemy-eth
     httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
     wsURL: "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
     healthCheck:
       useWsForBlockHeight: false
-  - id: ankr-polygon
-    httpURL: "https://rpc.ankr.com/polygon"
-    wsURL: "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}"
-  - id: my-node
-    httpURL: "http://12.57.207.168:8545"
-    wsURL: "wss://12.57.207.168:8546"
+    group: fallback

--- a/internal/checks/blockheight.go
+++ b/internal/checks/blockheight.go
@@ -95,7 +95,7 @@ func (c *BlockHeightCheck) runCheckHTTP() {
 
 	c.BlockHeight = header.Number.Uint64()
 
-	zap.L().Debug("Ran BlockHeightCheck over HTTP.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.String("WSURL", c.upstreamConfig.WSURL))
+	zap.L().Debug("Ran BlockHeightCheck over HTTP.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.String("WSURL", c.upstreamConfig.WSURL), zap.Uint64("blockHeight", c.BlockHeight))
 }
 
 func (c *BlockHeightCheck) IsPassing(maxBlockHeight uint64) bool {

--- a/internal/checks/manager.go
+++ b/internal/checks/manager.go
@@ -111,7 +111,7 @@ func (h *healthCheckManager) runPeriodicChecks(configs []conf.UpstreamConfig) {
 
 		for i := range configs {
 			config := configs[i]
-			zap.L().Debug("Running healthchecks on config", zap.String("config", fmt.Sprintf("%v", config)))
+			zap.L().Debug("Running healthchecks on config", zap.String("config", fmt.Sprintf("%+v", config)))
 
 			wg.Add(1)
 

--- a/internal/checks/syncing.go
+++ b/internal/checks/syncing.go
@@ -75,7 +75,7 @@ func (c *SyncingCheck) runCheck() {
 	c.err = err
 	c.isSyncing = syncProgress != nil
 
-	zap.L().Debug("Ran SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig), zap.Any("syncProgress", syncProgress), zap.Error(err))
+	zap.L().Debug("Ran SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Any("syncProgress", syncProgress), zap.Error(err))
 }
 
 func (c *SyncingCheck) IsPassing() bool {

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -31,18 +31,31 @@ type SimpleRouter struct {
 	upstreamsMutex     *sync.RWMutex
 	healthCheckManager checks.HealthCheckManager
 	routingStrategy    RoutingStrategy
-	upstreamConfigs    []config.UpstreamConfig
+	// Map from UpstreamID => `config.UpstreamConfig`
+	upstreamConfigs map[string]config.UpstreamConfig
+	// Map from GroupID => `config.GroupConfig`
+	groupConfigs map[string]config.GroupConfig
 }
 
-func NewRouter(upstreamConfigs []config.UpstreamConfig) Router {
+func NewRouter(upstreamConfigs []config.UpstreamConfig, groupConfigs []config.GroupConfig) Router {
 	healthCheckManager := checks.NewHealthCheckManager(client.NewEthClient, upstreamConfigs)
+
+	upstreamConfigMap := make(map[string]config.UpstreamConfig)
+	for _, upstreamConfig := range upstreamConfigs {
+		upstreamConfigMap[upstreamConfig.ID] = upstreamConfig
+	}
+
+	groupMap := make(map[string]config.GroupConfig)
+	for _, groupConfig := range groupConfigs {
+		groupMap[groupConfig.ID] = groupConfig
+	}
 
 	r := &SimpleRouter{
 		healthCheckManager: healthCheckManager,
-		upstreamConfigs:    upstreamConfigs,
+		upstreamConfigs:    upstreamConfigMap,
+		groupConfigs:       groupMap,
 		upstreamsMutex:     &sync.RWMutex{},
-		// Only support RoundRobin for now.
-		routingStrategy: NewRoundRobinStrategy(),
+		routingStrategy:    NewPriorityRoundRobinStrategy(),
 	}
 
 	return r
@@ -54,6 +67,7 @@ func (r *SimpleRouter) Start() {
 
 func (r *SimpleRouter) Route(requestBody jsonrpc.RequestBody) (*jsonrpc.ResponseBody, *http.Response, error) {
 	healthyUpstreams := r.healthCheckManager.GetHealthyUpstreams()
+
 	if len(healthyUpstreams) == 0 {
 		httpResp := &http.Response{
 			StatusCode: http.StatusServiceUnavailable,
@@ -63,16 +77,9 @@ func (r *SimpleRouter) Route(requestBody jsonrpc.RequestBody) (*jsonrpc.Response
 		return nil, httpResp, nil
 	}
 
-	id := r.routingStrategy.routeNextRequest(healthyUpstreams)
-
-	var configToRoute config.UpstreamConfig
-
-	for _, config := range r.upstreamConfigs {
-		if config.ID == id {
-			configToRoute = config
-			break
-		}
-	}
+	upstreamsByPriority := groupUpstreamsByPriority(healthyUpstreams, r.upstreamConfigs, r.groupConfigs)
+	id := r.routingStrategy.routeNextRequest(upstreamsByPriority)
+	configToRoute := r.upstreamConfigs[id]
 
 	zap.L().Debug("Routing request to config.", zap.Any("request", requestBody), zap.Any("config", configToRoute))
 
@@ -111,4 +118,22 @@ func (r *SimpleRouter) Route(requestBody jsonrpc.RequestBody) (*jsonrpc.Response
 	zap.L().Debug("Successfully routed request to config.", zap.Any("request", requestBody), zap.Any("response", respBody), zap.Any("config", configToRoute))
 
 	return respBody, resp, nil
+}
+
+func groupUpstreamsByPriority(upstreams []string, upstreamConfigs map[string]config.UpstreamConfig, groupConfigs map[string]config.GroupConfig) map[int][]string {
+	priorityMap := make(map[int][]string)
+	usingGroups := len(groupConfigs) > 0
+
+	for _, upstream := range upstreams {
+		groupID := upstreamConfigs[upstream].GroupID
+
+		groupPriority := 0
+		if usingGroups {
+			groupPriority = groupConfigs[groupID].Priority
+		}
+
+		priorityMap[groupPriority] = append(priorityMap[groupPriority], upstream)
+	}
+
+	return priorityMap
 }

--- a/internal/route/routing_strategy_test.go
+++ b/internal/route/routing_strategy_test.go
@@ -1,0 +1,48 @@
+package route
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPriorityStrategy_HighPriority(t *testing.T) {
+	upstreams := map[int][]string{
+		0: {"geth", "something-else"},
+		1: {"erigon"},
+	}
+
+	strategy := NewPriorityRoundRobinStrategy()
+
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, "something-else", strategy.routeNextRequest(upstreams))
+		assert.Equal(t, "geth", strategy.routeNextRequest(upstreams))
+	}
+}
+
+func TestPriorityStrategy_LowerPriority(t *testing.T) {
+	upstreams := map[int][]string{
+		0: {},
+		1: {"fallback1", "fallback2"},
+	}
+
+	strategy := NewPriorityRoundRobinStrategy()
+
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, "fallback2", strategy.routeNextRequest(upstreams))
+		assert.Equal(t, "fallback1", strategy.routeNextRequest(upstreams))
+	}
+}
+
+func TestPriorityStrategy_NoUpstreams(t *testing.T) {
+	upstreams := map[int][]string{
+		0: {},
+		1: {},
+	}
+
+	strategy := NewPriorityRoundRobinStrategy()
+
+	for i := 0; i < 10; i++ {
+		assert.Equal(t, "", strategy.routeNextRequest(upstreams))
+	}
+}

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -27,7 +27,7 @@ type RPCServer struct {
 }
 
 func NewRPCServer(config conf.Config) RPCServer {
-	router := route.NewRouter(config.Upstreams)
+	router := route.NewRouter(config.Upstreams, config.Groups)
 	handler := &RPCHandler{
 		router: router,
 	}
@@ -93,7 +93,7 @@ func (h *RPCHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	zap.L().Info("Request received.", zap.String("method", req.Method), zap.String("path", req.URL.Path), zap.String("query", req.URL.RawQuery), zap.Any("body", body))
+	zap.L().Debug("Request received.", zap.String("method", req.Method), zap.String("path", req.URL.Path), zap.String("query", req.URL.RawQuery), zap.Any("body", body))
 
 	respBody, resp, err := h.router.Route(body)
 	if resp != nil {


### PR DESCRIPTION
* Implementing [RFC](https://www.notion.so/satsuma-xyz/RFC-Priority-Load-Balancing-1f7cb9943c4b41a8b414ab41f6c4e58a#e839c6029b544e02ac04304d29f80097)
* Updated some logging

# Testing

Ran the gateway locally against our geth & erigon instances. 
config:
```
global:
  port: 8080

groups:
  - id: primary
    priority: 0
  - id: fallback
    priority: 1

upstreams:
  - id: satsuma-erigon
    httpURL: "http://3.237.178.236:8545"
    group: primary
  - id: satsuma-geth
    httpURL: "http://35.173.249.208:8545"
    wsURL: "wss:rofl:4"
    group: fallback
```

Cutoff connection to the `primary` (erigon) via EC2 security groups

```
{"level":"info","ts":1661292167.951573,"caller":"route/routing_strategy.go:124","msg":"Did not find any healthy nodes in priority","priority":0,"group":"primary","candidateUpstreams":["satsuma-erigon"]}
{"level":"info","ts":1661292167.9515991,"caller":"route/router.go:70","msg":"Routing request to upstream.","id":"satsuma-geth"}
```
