### PR TITLE
Create PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Description
+
+*Please include a summary of the changes. Please also include relevant motivation and context.*
+
+## Type of change
+
+- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
+- [ ] 😎 New feature (non-breaking change which adds functionality)
+- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] ⚒️ Refactor (no functional changes)
+- [ ] 📖 Documentation (updating or adding docs)
+
+# How Has This Been Tested?
+
+*Please describe the tests that you ran to verify your changes.*


### PR DESCRIPTION
- Facilitates good documentation for PR
- Enables more streamlined PR reviews

Followed this guide: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository