### PR TITLE
fix: Setting response headers properly and adding some logs

### DIFF
--- a/internal/checks/peers.go
+++ b/internal/checks/peers.go
@@ -46,6 +46,8 @@ func (c *PeerCheck) Initialize() error {
 	c.runCheck()
 
 	if isMethodNotSupportedErr(c.err) {
+		zap.L().Debug("PeerCheck is not supported by upstream, not running check.", zap.Any("upstreamID", c.upstreamConfig))
+
 		c.shouldRun = false
 	}
 

--- a/internal/checks/syncing.go
+++ b/internal/checks/syncing.go
@@ -48,6 +48,8 @@ func (c *SyncingCheck) Initialize() error {
 	c.runCheck()
 
 	if isMethodNotSupportedErr(c.err) {
+		zap.L().Debug("PeerCheck is not supported by upstream, not running check.", zap.Any("upstreamID", c.upstreamConfig))
+
 		c.shouldRun = false
 	}
 

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -85,13 +85,13 @@ func (r *SimpleRouter) Route(requestBody jsonrpc.RequestBody) (*jsonrpc.Response
 
 	bodyBytes, err := requestBody.EncodeRequestBody()
 	if err != nil {
-		zap.L().Error("Could not serialize request", zap.Any("request", requestBody), zap.Error(err))
+		zap.L().Error("Could not serialize request.", zap.Any("request", requestBody), zap.Error(err))
 		return nil, nil, err
 	}
 
 	httpReq, err := http.NewRequestWithContext(context.Background(), "POST", configToRoute.HTTPURL, bytes.NewReader(bodyBytes))
 	if err != nil {
-		zap.L().Error("Could not create new http request", zap.Any("request", requestBody), zap.Error(err))
+		zap.L().Error("Could not create new http request.", zap.Any("request", requestBody), zap.Error(err))
 		return nil, nil, err
 	}
 
@@ -104,14 +104,14 @@ func (r *SimpleRouter) Route(requestBody jsonrpc.RequestBody) (*jsonrpc.Response
 	resp, err := httpClient.Do(httpReq)
 
 	if err != nil {
-		zap.L().Error("Error encountered when executing request", zap.Any("request", requestBody), zap.String("response", fmt.Sprintf("%v", resp)), zap.Error(err))
+		zap.L().Error("Error encountered when executing request.", zap.Any("request", requestBody), zap.String("response", fmt.Sprintf("%v", resp)), zap.Error(err))
 		return nil, nil, err
 	}
 	defer resp.Body.Close()
 
 	respBody, err := jsonrpc.DecodeResponseBody(resp)
 	if err != nil {
-		zap.L().Error("Could not deserialize response", zap.Any("request", requestBody), zap.String("response", fmt.Sprintf("%v", resp)), zap.Error(err))
+		zap.L().Warn("Could not deserialize response.", zap.Any("request", requestBody), zap.String("response", fmt.Sprintf("%v", resp)), zap.Error(err))
 		return nil, nil, err
 	}
 

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -130,8 +130,11 @@ func respondJSONRPC(writer http.ResponseWriter, response *jsonrpc.ResponseBody, 
 		return
 	}
 
-	writer.WriteHeader(httpStatusCode)
 	writer.Header().Set("Content-Type", "application/json")
+
+	// Note: Call `WriteHeader` last otherwise headers won't get written.
+	// See Header() on the http.ResponseWriter interface for more information.
+	writer.WriteHeader(httpStatusCode)
 
 	if i, err := writer.Write(respBytes); err != nil {
 		zap.L().Error("Failed to write JSON RPC response body.", zap.Error(err), zap.Int("bytesWritten", i), zap.String("response", string(respBytes)))
@@ -145,8 +148,11 @@ func respondJSON(writer http.ResponseWriter, message string, httpStatusCode int)
 		resp["message"] = message
 	}
 
-	writer.WriteHeader(httpStatusCode)
 	writer.Header().Set("Content-Type", "application/json")
+
+	// Note: Call `WriteHeader` last otherwise headers won't get written.
+	// See Header() on the http.ResponseWriter interface for more information.
+	writer.WriteHeader(httpStatusCode)
 
 	jsonResp, _ := json.Marshal(resp)
 	if i, err := writer.Write(jsonResp); err != nil {


### PR DESCRIPTION
* Content type in response was "text/plain". This was due to incorrect ordering or writing headers. 
* Add a few log statements