### PR TITLE
feat: improvements to metrics - recording client, jsonrpc methods, up…

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -57,7 +57,7 @@ var (
 			Name:      "upstream_rpc_requests_total",
 			Help:      "Count of total RPC requests forwarded to upstreams.",
 		},
-		[]string{"endpoint_id", "url"},
+		[]string{"client", "endpoint_id", "url", "jsonrpc_method"},
 	)
 
 	UpstreamRPCRequestErrorsTotal = promauto.NewCounterVec(
@@ -67,7 +67,18 @@ var (
 			Name:      "upstream_rpc_request_errors_total",
 			Help:      "Count of total errors when forwarding RPC requests to upstreams.",
 		},
-		[]string{"endpoint_id", "url", "response_code", "jsonrpc_error_code"},
+		[]string{"client", "endpoint_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
+	)
+
+	UpstreamRPCDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "upstream_rpc_duration_seconds",
+			Help:      "Latency of RPC requests forwarded to upstreams.",
+			Buckets:   []float64{0.1, .5, 1, 5, 10, 30, 60},
+		},
+		[]string{"client", "endpoint_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
 	)
 )
 

--- a/internal/mocks/Router.go
+++ b/internal/mocks/Router.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	context "context"
 	http "net/http"
 
 	jsonrpc "github.com/satsuma-data/node-gateway/internal/jsonrpc"
@@ -14,13 +15,13 @@ type Router struct {
 	mock.Mock
 }
 
-// Route provides a mock function with given fields: requestBody
-func (_m *Router) Route(requestBody jsonrpc.RequestBody) (*jsonrpc.ResponseBody, *http.Response, error) {
-	ret := _m.Called(requestBody)
+// Route provides a mock function with given fields: ctx, requestBody
+func (_m *Router) Route(ctx context.Context, requestBody jsonrpc.RequestBody) (*jsonrpc.ResponseBody, *http.Response, error) {
+	ret := _m.Called(ctx, requestBody)
 
 	var r0 *jsonrpc.ResponseBody
-	if rf, ok := ret.Get(0).(func(jsonrpc.RequestBody) *jsonrpc.ResponseBody); ok {
-		r0 = rf(requestBody)
+	if rf, ok := ret.Get(0).(func(context.Context, jsonrpc.RequestBody) *jsonrpc.ResponseBody); ok {
+		r0 = rf(ctx, requestBody)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*jsonrpc.ResponseBody)
@@ -28,8 +29,8 @@ func (_m *Router) Route(requestBody jsonrpc.RequestBody) (*jsonrpc.ResponseBody,
 	}
 
 	var r1 *http.Response
-	if rf, ok := ret.Get(1).(func(jsonrpc.RequestBody) *http.Response); ok {
-		r1 = rf(requestBody)
+	if rf, ok := ret.Get(1).(func(context.Context, jsonrpc.RequestBody) *http.Response); ok {
+		r1 = rf(ctx, requestBody)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*http.Response)
@@ -37,8 +38,8 @@ func (_m *Router) Route(requestBody jsonrpc.RequestBody) (*jsonrpc.ResponseBody,
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(jsonrpc.RequestBody) error); ok {
-		r2 = rf(requestBody)
+	if rf, ok := ret.Get(2).(func(context.Context, jsonrpc.RequestBody) error); ok {
+		r2 = rf(ctx, requestBody)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -1,6 +1,7 @@
 package route
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -28,7 +29,7 @@ func TestRouter_NoHealthyUpstreams(t *testing.T) {
 	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0))
 	router.(*SimpleRouter).healthCheckManager = managerMock
 
-	jsonResp, httpResp, err := router.Route(jsonrpc.RequestBody{})
+	jsonResp, httpResp, err := router.Route(context.Background(), jsonrpc.RequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, jsonResp)
@@ -100,7 +101,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 	router.(*SimpleRouter).httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	jsonRcpResp, httpResp, err := router.Route(jsonrpc.RequestBody{})
+	jsonRcpResp, httpResp, err := router.Route(context.Background(), jsonrpc.RequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)
@@ -145,7 +146,7 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 	router.(*SimpleRouter).httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	jsonRcpResp, httpResp, err := router.Route(jsonrpc.RequestBody{})
+	jsonRcpResp, httpResp, err := router.Route(context.Background(), jsonrpc.RequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)

--- a/internal/server/web_server_test.go
+++ b/internal/server/web_server_test.go
@@ -24,7 +24,7 @@ func TestHandleJSONRPCRequest_Success(t *testing.T) {
 		Result:  "results",
 		ID:      2,
 	}
-	router.On("Route", mock.Anything).
+	router.On("Route", mock.Anything, mock.Anything).
 		Return(expectedRPCResponse,
 			&http.Response{
 				StatusCode: http.StatusOK,
@@ -123,7 +123,7 @@ func TestHandleJSONRPCRequest_UnknownBodyField(t *testing.T) {
 func TestHandleJSONRPCRequest_NilJSONRPCResponse(t *testing.T) {
 	router := mocks.NewRouter(t)
 
-	router.On("Route", mock.Anything).
+	router.On("Route", mock.Anything, mock.Anything).
 		Return(nil,
 			&http.Response{
 				StatusCode: http.StatusAccepted,
@@ -152,7 +152,7 @@ func TestHandleJSONRPCRequest_JSONRPCDecodeError(t *testing.T) {
 	router := mocks.NewRouter(t)
 	undecodableContent := []byte("content")
 
-	router.On("Route", mock.Anything).
+	router.On("Route", mock.Anything, mock.Anything).
 		Return(nil, nil, jsonrpc.DecodeError{Err: errors.New("error decoding"), Content: undecodableContent})
 
 	handler := &RPCHandler{router: router}

--- a/internal/util/context.go
+++ b/internal/util/context.go
@@ -1,0 +1,22 @@
+package util
+
+import "context"
+
+type contextKey string
+
+const (
+	clientContextKey contextKey = "client"
+)
+
+func NewContext(ctx context.Context, client string) context.Context {
+	return context.WithValue(ctx, clientContextKey, client)
+}
+
+// FromContext returns the User value stored in ctx, if any.
+func GetClientFromContext(ctx context.Context) string {
+	if client := ctx.Value(clientContextKey); client != nil {
+		return client.(string)
+	}
+
+	return ""
+}


### PR DESCRIPTION
# Description
* Recording the client who made the request as part of the request's query parameter.  Using `context` to pass this around.
* Upstream latency metrics
* Small code quality changes in `router`

In the next PR, I plan to add metrics around the health checks. Latency, errors, block height, # healthy upstreams etc.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

```
➜  node-gateway git:(sample) ✗ curl --location --request POST 'localhost:8080/?client=brians_laptop' --header 'Content-Type: application/json' --data-raw '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":["0xb2fea9c4b24775af6990237aa90228e5e092c56bdaee74496992a53c208da1ee"],"id":1}' 

...
...
...
➜  node-gateway git:(sample) ✗ curl localhost:9090
...
...
# HELP satsuma_node_gateway_upstream_rpc_duration_seconds Latency of RPC requests forwarded to upstreams.
# TYPE satsuma_node_gateway_upstream_rpc_duration_seconds histogram
satsuma_node_gateway_upstream_rpc_duration_seconds_bucket{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_error_code="",jsonrpc_method="eth_getTransactionByHash",response_code="200",url="http://35.171.183.44:8545",le="0.1"} 1
satsuma_node_gateway_upstream_rpc_duration_seconds_bucket{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_error_code="",jsonrpc_method="eth_getTransactionByHash",response_code="200",url="http://35.171.183.44:8545",le="0.5"} 1
satsuma_node_gateway_upstream_rpc_duration_seconds_bucket{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_error_code="",jsonrpc_method="eth_getTransactionByHash",response_code="200",url="http://35.171.183.44:8545",le="1"} 1
satsuma_node_gateway_upstream_rpc_duration_seconds_bucket{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_error_code="",jsonrpc_method="eth_getTransactionByHash",response_code="200",url="http://35.171.183.44:8545",le="5"} 1
satsuma_node_gateway_upstream_rpc_duration_seconds_bucket{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_error_code="",jsonrpc_method="eth_getTransactionByHash",response_code="200",url="http://35.171.183.44:8545",le="10"} 1
satsuma_node_gateway_upstream_rpc_duration_seconds_bucket{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_error_code="",jsonrpc_method="eth_getTransactionByHash",response_code="200",url="http://35.171.183.44:8545",le="30"} 1
satsuma_node_gateway_upstream_rpc_duration_seconds_bucket{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_error_code="",jsonrpc_method="eth_getTransactionByHash",response_code="200",url="http://35.171.183.44:8545",le="60"} 1
satsuma_node_gateway_upstream_rpc_duration_seconds_bucket{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_error_code="",jsonrpc_method="eth_getTransactionByHash",response_code="200",url="http://35.171.183.44:8545",le="+Inf"} 1
satsuma_node_gateway_upstream_rpc_duration_seconds_sum{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_error_code="",jsonrpc_method="eth_getTransactionByHash",response_code="200",url="http://35.171.183.44:8545"} 0.086695541
satsuma_node_gateway_upstream_rpc_duration_seconds_count{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_error_code="",jsonrpc_method="eth_getTransactionByHash",response_code="200",url="http://35.171.183.44:8545"} 1
# HELP satsuma_node_gateway_upstream_rpc_requests_total Count of total RPC requests forwarded to upstreams.
# TYPE satsuma_node_gateway_upstream_rpc_requests_total counter
satsuma_node_gateway_upstream_rpc_requests_total{client="brians_laptop",endpoint_id="satsuma-erigon-2",jsonrpc_method="eth_getTransactionByHash",url="http://35.171.183.44:8545"} 1
```