### PR TITLE
ci: make sure commit msg starts with lower case after the commit type

### DIFF
--- a/scripts/lint_commit_message.sh
+++ b/scripts/lint_commit_message.sh
@@ -4,7 +4,7 @@ VALID_COMMIT_REGEX=""
 
 ALLOWED_TYPES=("build" "chore" "ci" "docs" "feat" "fix" "perf" "refactor" "revert" "style" "test")
 for TYPE in ${ALLOWED_TYPES[@]}; do
-  VALID_COMMIT_REGEX="$VALID_COMMIT_REGEX$TYPE(\([a-zA-Z0-9 ]+\)){0,1}(!){0,1}: |"
+  VALID_COMMIT_REGEX="$VALID_COMMIT_REGEX$TYPE(\([a-zA-Z0-9 ]+\)){0,1}(!){0,1}: [a-z]|"
 done
 
 # Remove trailing pipe.


### PR DESCRIPTION


## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?
```
➜  node-gateway git:(more_metrics) ✗ ./scripts/lint_commit_message.sh "fix: H"
Commit message does follow the conventional commit format.
➜  node-gateway git:(more_metrics) ✗ ./scripts/lint_commit_message.sh "fix: h"
➜  node-gateway git:(more_metrics) ✗ ./scripts/lint_commit_message.sh "fix: hi"
```
