### PR TITLE
feat: metrics on health checks

### DIFF
--- a/internal/checks/blockheight.go
+++ b/internal/checks/blockheight.go
@@ -68,7 +68,7 @@ func (c *BlockHeightCheck) initializeWebsockets() error {
 func (c *BlockHeightCheck) initializeHTTP() {
 	httpClient, err := c.clientGetter(c.upstreamConfig.HTTPURL, &client.BasicAuthCredentials{Username: c.upstreamConfig.BasicAuthConfig.Username, Password: c.upstreamConfig.BasicAuthConfig.Password})
 	if err != nil {
-		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.BlockHeightCheckErrorTypeHTTP).Inc()
+		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPInit).Inc()
 		c.blockHeightError = err
 
 		return
@@ -97,7 +97,7 @@ func (c *BlockHeightCheck) runCheckHTTP() {
 	runCheck := func() {
 		header, err := c.httpClient.HeaderByNumber(context.Background(), nil)
 		if c.blockHeightError = err; c.blockHeightError != nil {
-			metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.BlockHeightCheckErrorTypeHTTP).Inc()
+			metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPRequest).Inc()
 			return
 		}
 
@@ -141,7 +141,7 @@ func (c *BlockHeightCheck) subscribeNewHead() error {
 	onError := func(failure string) {
 		zap.L().Error("Encountered error in NewHead Websockets subscription.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.String("WSURL", c.upstreamConfig.WSURL))
 
-		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.BlockHeightCheckErrorTypeWSError).Inc()
+		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.WSError).Inc()
 		c.webSocketError = errors.New(failure)
 		c.blockHeightError = c.webSocketError
 	}
@@ -153,7 +153,7 @@ func (c *BlockHeightCheck) subscribeNewHead() error {
 	}
 
 	if err = subscribeNewHeads(wsClient, &newHeadHandler{onNewHead: onNewHead, onError: onError}); err != nil {
-		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.BlockHeightCheckErrorTypeWSSubscribe).Inc()
+		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.WSSubscribe).Inc()
 		c.webSocketError = err
 
 		return err

--- a/internal/checks/blockheight.go
+++ b/internal/checks/blockheight.go
@@ -68,7 +68,7 @@ func (c *BlockHeightCheck) initializeWebsockets() error {
 func (c *BlockHeightCheck) initializeHTTP() {
 	httpClient, err := c.clientGetter(c.upstreamConfig.HTTPURL, &client.BasicAuthCredentials{Username: c.upstreamConfig.BasicAuthConfig.Username, Password: c.upstreamConfig.BasicAuthConfig.Password})
 	if err != nil {
-		metrics.BlockHeightErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
 		c.blockHeightError = err
 
 		return
@@ -97,7 +97,7 @@ func (c *BlockHeightCheck) runCheckHTTP() {
 	runCheck := func() {
 		header, err := c.httpClient.HeaderByNumber(context.Background(), nil)
 		if c.blockHeightError = err; c.blockHeightError != nil {
-			metrics.BlockHeightErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+			metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
 			return
 		}
 
@@ -108,8 +108,8 @@ func (c *BlockHeightCheck) runCheckHTTP() {
 	}
 
 	runCheckWithMetrics(runCheck,
-		metrics.BlockHeightTotalRequests.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL),
-		metrics.BlockHeightDuration.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL))
+		metrics.BlockHeightCheckRequests.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL),
+		metrics.BlockHeightCheckDuration.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL))
 }
 
 func (c *BlockHeightCheck) IsPassing(maxBlockHeight uint64) bool {
@@ -141,7 +141,7 @@ func (c *BlockHeightCheck) subscribeNewHead() error {
 	onError := func(failure string) {
 		zap.L().Error("Encountered error in NewHead Websockets subscription.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.String("WSURL", c.upstreamConfig.WSURL))
 
-		metrics.BlockHeightErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
 		c.webSocketError = errors.New(failure)
 		c.blockHeightError = c.webSocketError
 	}

--- a/internal/checks/check.go
+++ b/internal/checks/check.go
@@ -2,8 +2,10 @@ package checks
 
 import (
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
@@ -25,6 +27,14 @@ func isMethodNotSupportedErr(err error) bool {
 		// match rpc.Error.
 		return strings.Contains(strings.ToLower(err.Error()), "unsupported method")
 	}
+}
+
+func runCheckWithMetrics(runCheck func(), counterMetrics prometheus.Counter, durationMetrics prometheus.Observer) {
+	start := time.Now()
+
+	counterMetrics.Inc()
+	runCheck()
+	durationMetrics.Observe(time.Since(start).Seconds())
 }
 
 //go:generate mockery --output ../mocks --name Checker

--- a/internal/checks/peers.go
+++ b/internal/checks/peers.go
@@ -59,7 +59,7 @@ func (c *PeerCheck) RunCheck() {
 	if c.client == nil {
 		if err := c.Initialize(); err != nil {
 			zap.L().Error("Errorr initializing PeerCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Error(err))
-			metrics.PeerCountErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+			metrics.PeerCountCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
 		}
 	}
 
@@ -76,7 +76,7 @@ func (c *PeerCheck) runCheck() {
 	runCheck := func() {
 		peerCount, err := c.client.PeerCount(context.Background())
 		if c.err = err; c.err != nil {
-			metrics.PeerCountErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+			metrics.PeerCountCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
 			return
 		}
 
@@ -87,8 +87,8 @@ func (c *PeerCheck) runCheck() {
 	}
 
 	runCheckWithMetrics(runCheck,
-		metrics.PeerCountTotalRequests.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL),
-		metrics.PeerCountDuration.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL))
+		metrics.PeerCountCheckRequests.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL),
+		metrics.PeerCountCheckDuration.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL))
 }
 
 func (c *PeerCheck) IsPassing() bool {

--- a/internal/checks/peers.go
+++ b/internal/checks/peers.go
@@ -59,7 +59,7 @@ func (c *PeerCheck) RunCheck() {
 	if c.client == nil {
 		if err := c.Initialize(); err != nil {
 			zap.L().Error("Errorr initializing PeerCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Error(err))
-			metrics.PeerCountCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+			metrics.PeerCountCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPInit).Inc()
 		}
 	}
 
@@ -76,7 +76,7 @@ func (c *PeerCheck) runCheck() {
 	runCheck := func() {
 		peerCount, err := c.client.PeerCount(context.Background())
 		if c.err = err; c.err != nil {
-			metrics.PeerCountCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+			metrics.PeerCountCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPRequest).Inc()
 			return
 		}
 

--- a/internal/checks/syncing.go
+++ b/internal/checks/syncing.go
@@ -61,7 +61,7 @@ func (c *SyncingCheck) RunCheck() {
 	if c.client == nil {
 		if err := c.Initialize(); err != nil {
 			zap.L().Error("Error initializing SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Error(err))
-			metrics.SyncStatusErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+			metrics.SyncStatusCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
 		}
 	}
 
@@ -78,7 +78,7 @@ func (c *SyncingCheck) runCheck() {
 	runCheck := func() {
 		result, err := c.client.SyncProgress(context.Background())
 		if c.err = err; err != nil {
-			metrics.SyncStatusErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+			metrics.SyncStatusCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
 			return
 		}
 
@@ -95,8 +95,8 @@ func (c *SyncingCheck) runCheck() {
 	}
 
 	runCheckWithMetrics(runCheck,
-		metrics.SyncStatusTotalRequests.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL),
-		metrics.SyncStatusDuration.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL))
+		metrics.SyncStatusCheckRequests.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL),
+		metrics.SyncStatusCheckDuration.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL))
 }
 
 func (c *SyncingCheck) IsPassing() bool {

--- a/internal/checks/syncing.go
+++ b/internal/checks/syncing.go
@@ -61,7 +61,7 @@ func (c *SyncingCheck) RunCheck() {
 	if c.client == nil {
 		if err := c.Initialize(); err != nil {
 			zap.L().Error("Error initializing SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Error(err))
-			metrics.SyncStatusCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+			metrics.SyncStatusCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPInit).Inc()
 		}
 	}
 
@@ -78,7 +78,7 @@ func (c *SyncingCheck) runCheck() {
 	runCheck := func() {
 		result, err := c.client.SyncProgress(context.Background())
 		if c.err = err; err != nil {
-			metrics.SyncStatusCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+			metrics.SyncStatusCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPRequest).Inc()
 			return
 		}
 

--- a/internal/checks/syncing.go
+++ b/internal/checks/syncing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/satsuma-data/node-gateway/internal/client"
 	conf "github.com/satsuma-data/node-gateway/internal/config"
+	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"go.uber.org/zap"
 )
 
@@ -60,6 +61,7 @@ func (c *SyncingCheck) RunCheck() {
 	if c.client == nil {
 		if err := c.Initialize(); err != nil {
 			zap.L().Error("Error initializing SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Error(err))
+			metrics.SyncStatusErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
 		}
 	}
 
@@ -73,11 +75,28 @@ func (c *SyncingCheck) runCheck() {
 		return
 	}
 
-	syncProgress, err := c.client.SyncProgress(context.Background())
-	c.err = err
-	c.isSyncing = syncProgress != nil
+	runCheck := func() {
+		result, err := c.client.SyncProgress(context.Background())
+		if c.err = err; err != nil {
+			metrics.SyncStatusErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Inc()
+			return
+		}
 
-	zap.L().Debug("Ran SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Any("syncProgress", syncProgress), zap.Error(err))
+		c.isSyncing = result != nil
+
+		gauge := 0
+		if c.isSyncing {
+			gauge = 1
+		}
+
+		metrics.SyncStatus.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Set(float64(gauge))
+
+		zap.L().Debug("Ran SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Any("syncProgress", result))
+	}
+
+	runCheckWithMetrics(runCheck,
+		metrics.SyncStatusTotalRequests.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL),
+		metrics.SyncStatusDuration.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL))
 }
 
 func (c *SyncingCheck) IsPassing() bool {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -12,16 +12,17 @@ import (
 
 const (
 	DefaultPort              = 9090
-	metricsNamespace         = "satsuma"
-	metricsSubsystem         = "node_gateway"
+	metricsNamespace         = "node_gateway"
 	defaultReadHeaderTimeout = 10 * time.Second
 )
 
 var (
+	// Overall metrics
+
 	rpcRequestsCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
-			Subsystem: metricsSubsystem,
+			Subsystem: "server",
 			Name:      "rpc_requests_total",
 			Help:      "Count of total RPC requests.",
 		},
@@ -31,10 +32,10 @@ var (
 	rpcRequestsDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
-			Subsystem: metricsSubsystem,
+			Subsystem: "server",
 			Name:      "rpc_request_duration_seconds",
 			Help:      "Histogram of RPC request latencies.",
-			Buckets:   []float64{0.1, .5, 1, 5, 10, 30, 60},
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
 		},
 		[]string{"code", "method"},
 	)
@@ -42,7 +43,7 @@ var (
 	rpcResponseSizes = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
-			Subsystem: metricsSubsystem,
+			Subsystem: "server",
 			Name:      "rpc_response_size_bytes",
 			Help:      "Histogram of RPC response sizes.",
 			Buckets:   []float64{100, 500, 1000, 5000, 10000},
@@ -50,10 +51,12 @@ var (
 		[]string{"code", "method"},
 	)
 
+	// Upstream routing metrics
+
 	UpstreamRPCRequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
-			Subsystem: metricsSubsystem,
+			Subsystem: "router",
 			Name:      "upstream_rpc_requests_total",
 			Help:      "Count of total RPC requests forwarded to upstreams.",
 		},
@@ -63,7 +66,7 @@ var (
 	UpstreamRPCRequestErrorsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
-			Subsystem: metricsSubsystem,
+			Subsystem: "router",
 			Name:      "upstream_rpc_request_errors_total",
 			Help:      "Count of total errors when forwarding RPC requests to upstreams.",
 		},
@@ -73,12 +76,138 @@ var (
 	UpstreamRPCDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
-			Subsystem: metricsSubsystem,
+			Subsystem: "router",
 			Name:      "upstream_rpc_duration_seconds",
 			Help:      "Latency of RPC requests forwarded to upstreams.",
-			Buckets:   []float64{0.1, .5, 1, 5, 10, 30, 60},
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
 		},
 		[]string{"client", "endpoint_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
+	)
+
+	// Health check metrics
+
+	BlockHeight = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "block_height",
+			Help:      "Block height of upstream.",
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	BlockHeightTotalRequests = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "block_height_total",
+			Help:      "Total block height requests made.",
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	BlockHeightDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "block_height_duration_seconds",
+			Help:      "Latency of block height requests.",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	BlockHeightErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "block_height_errors",
+			Help:      "Errors when retrieving block height of upstream.",
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	PeerCount = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "peer_count",
+			Help:      "Block height of upstream.",
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	PeerCountTotalRequests = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "peer_count_total",
+			Help:      "Total peer count requests made.",
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	PeerCountDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "peer_count_duration_seconds",
+			Help:      "Latency of peer count requests.",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	PeerCountErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "peer_count_errors",
+			Help:      "Errors when retrieving peer count of upstream.",
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	// Use 0 or 1
+	SyncStatus = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "sync_status",
+			Help:      "Sync Status of upstream.",
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	SyncStatusTotalRequests = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "sync_status_total",
+			Help:      "Total sync status requests made.",
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	SyncStatusDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "sync_status_duration_seconds",
+			Help:      "Latency of sync status requests.",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
+		},
+		[]string{"endpoint_id", "url"},
+	)
+
+	SyncStatusErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "healthcheck",
+			Name:      "sync_status_errors",
+			Help:      "Errors when retrieving sync status of upstream.",
+		},
+		[]string{"endpoint_id", "url"},
 	)
 )
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -96,32 +96,32 @@ var (
 		[]string{"endpoint_id", "url"},
 	)
 
-	BlockHeightTotalRequests = promauto.NewCounterVec(
+	BlockHeightCheckRequests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
-			Name:      "block_height_total",
+			Name:      "block_height_check_requests",
 			Help:      "Total block height requests made.",
 		},
 		[]string{"endpoint_id", "url"},
 	)
 
-	BlockHeightDuration = promauto.NewHistogramVec(
+	BlockHeightCheckDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
-			Name:      "block_height_duration_seconds",
+			Name:      "block_height_check_duration_seconds",
 			Help:      "Latency of block height requests.",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
 		},
 		[]string{"endpoint_id", "url"},
 	)
 
-	BlockHeightErrors = promauto.NewCounterVec(
+	BlockHeightCheckErrors = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
-			Name:      "block_height_errors",
+			Name:      "block_height_check_errors",
 			Help:      "Errors when retrieving block height of upstream.",
 		},
 		[]string{"endpoint_id", "url"},
@@ -137,32 +137,32 @@ var (
 		[]string{"endpoint_id", "url"},
 	)
 
-	PeerCountTotalRequests = promauto.NewCounterVec(
+	PeerCountCheckRequests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
-			Name:      "peer_count_total",
+			Name:      "peer_count_check_requests",
 			Help:      "Total peer count requests made.",
 		},
 		[]string{"endpoint_id", "url"},
 	)
 
-	PeerCountDuration = promauto.NewHistogramVec(
+	PeerCountCheckDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
-			Name:      "peer_count_duration_seconds",
+			Name:      "peer_count_check_duration_seconds",
 			Help:      "Latency of peer count requests.",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
 		},
 		[]string{"endpoint_id", "url"},
 	)
 
-	PeerCountErrors = promauto.NewCounterVec(
+	PeerCountCheckErrors = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
-			Name:      "peer_count_errors",
+			Name:      "peer_count_check_errors",
 			Help:      "Errors when retrieving peer count of upstream.",
 		},
 		[]string{"endpoint_id", "url"},
@@ -179,32 +179,32 @@ var (
 		[]string{"endpoint_id", "url"},
 	)
 
-	SyncStatusTotalRequests = promauto.NewCounterVec(
+	SyncStatusCheckRequests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
-			Name:      "sync_status_total",
+			Name:      "sync_status_check_requests",
 			Help:      "Total sync status requests made.",
 		},
 		[]string{"endpoint_id", "url"},
 	)
 
-	SyncStatusDuration = promauto.NewHistogramVec(
+	SyncStatusCheckDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
-			Name:      "sync_status_duration_seconds",
+			Name:      "sync_status_check_duration_seconds",
 			Help:      "Latency of sync status requests.",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
 		},
 		[]string{"endpoint_id", "url"},
 	)
 
-	SyncStatusErrors = promauto.NewCounterVec(
+	SyncStatusCheckErrors = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
-			Name:      "sync_status_errors",
+			Name:      "sync_status_check_errors",
 			Help:      "Errors when retrieving sync status of upstream.",
 		},
 		[]string{"endpoint_id", "url"},

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -14,6 +14,11 @@ const (
 	DefaultPort              = 9090
 	metricsNamespace         = "node_gateway"
 	defaultReadHeaderTimeout = 10 * time.Second
+
+	// Metric labels
+	BlockHeightCheckErrorTypeWSSubscribe = "wsSubscribe"
+	BlockHeightCheckErrorTypeWSError     = "wsError"
+	BlockHeightCheckErrorTypeHTTP        = "http"
 )
 
 var (
@@ -124,7 +129,7 @@ var (
 			Name:      "block_height_check_errors",
 			Help:      "Errors when retrieving block height of upstream.",
 		},
-		[]string{"endpoint_id", "url"},
+		[]string{"endpoint_id", "url", "errorType"},
 	)
 
 	PeerCount = promauto.NewGaugeVec(

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -16,9 +16,14 @@ const (
 	defaultReadHeaderTimeout = 10 * time.Second
 
 	// Metric labels
-	BlockHeightCheckErrorTypeWSSubscribe = "wsSubscribe"
-	BlockHeightCheckErrorTypeWSError     = "wsError"
-	BlockHeightCheckErrorTypeHTTP        = "http"
+
+	// General health check error types
+	HTTPInit    = "httpInit"
+	HTTPRequest = "httpReq"
+
+	// BlockHeightCheck-specific errors
+	WSSubscribe = "wsSubscribe"
+	WSError     = "wsError"
 )
 
 var (
@@ -28,7 +33,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "server",
-			Name:      "rpc_requests_total",
+			Name:      "rpc_requests",
 			Help:      "Count of total RPC requests.",
 		},
 		[]string{"code", "method"},
@@ -62,7 +67,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "router",
-			Name:      "upstream_rpc_requests_total",
+			Name:      "upstream_rpc_requests",
 			Help:      "Count of total RPC requests forwarded to upstreams.",
 		},
 		[]string{"client", "endpoint_id", "url", "jsonrpc_method"},
@@ -72,7 +77,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "router",
-			Name:      "upstream_rpc_request_errors_total",
+			Name:      "upstream_rpc_request_errors",
 			Help:      "Count of total errors when forwarding RPC requests to upstreams.",
 		},
 		[]string{"client", "endpoint_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
@@ -105,7 +110,7 @@ var (
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
-			Name:      "block_height_check_requests",
+			Name:      "block_height_check",
 			Help:      "Total block height requests made.",
 		},
 		[]string{"endpoint_id", "url"},
@@ -170,7 +175,7 @@ var (
 			Name:      "peer_count_check_errors",
 			Help:      "Errors when retrieving peer count of upstream.",
 		},
-		[]string{"endpoint_id", "url"},
+		[]string{"endpoint_id", "url", "errorType"},
 	)
 
 	// Use 0 or 1
@@ -212,7 +217,7 @@ var (
 			Name:      "sync_status_check_errors",
 			Help:      "Errors when retrieving sync status of upstream.",
 		},
-		[]string{"endpoint_id", "url"},
+		[]string{"endpoint_id", "url", "errorType"},
 	)
 )
 


### PR DESCRIPTION
# Description

Metrics for health checks — counts, errors, latencies, check results

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

```
# HELP node_gateway_healthcheck_block_height Block height of upstream.
# TYPE node_gateway_healthcheck_block_height gauge
node_gateway_healthcheck_block_height{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 1.5454965e+07
node_gateway_healthcheck_block_height{endpoint_id="satsuma-erigon-2",url="http://35.171.183.44:8545"} 1.5454965e+07
# HELP node_gateway_healthcheck_block_height_duration_seconds Latency of block height requests.
# TYPE node_gateway_healthcheck_block_height_duration_seconds histogram
node_gateway_healthcheck_block_height_duration_seconds_bucket{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545",le="0.1"} 5
node_gateway_healthcheck_block_height_duration_seconds_sum{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 0.45845249899999996
node_gateway_healthcheck_block_height_duration_seconds_count{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 5
...
...
# HELP node_gateway_healthcheck_block_height_total Total block height requests made.
# TYPE node_gateway_healthcheck_block_height_total counter
node_gateway_healthcheck_block_height_total{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 5
node_gateway_healthcheck_block_height_total{endpoint_id="satsuma-erigon-2",url="http://35.171.183.44:8545"} 5





# HELP node_gateway_healthcheck_peer_count Block height of upstream.
# TYPE node_gateway_healthcheck_peer_count gauge
node_gateway_healthcheck_peer_count{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 33
node_gateway_healthcheck_peer_count{endpoint_id="satsuma-erigon-2",url="http://35.171.183.44:8545"} 33
# HELP node_gateway_healthcheck_peer_count_duration_seconds Latency of peer count requests.
# TYPE node_gateway_healthcheck_peer_count_duration_seconds histogram
node_gateway_healthcheck_peer_count_duration_seconds_bucket{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545",le="0.1"} 1
node_gateway_healthcheck_peer_count_duration_seconds_sum{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 0.972279084
node_gateway_healthcheck_peer_count_duration_seconds_count{endpoint_id="satsuma-erigon-2",url="http://35.171.183.44:8545"} 6
# HELP node_gateway_healthcheck_peer_count_total Total peer count requests made.
# TYPE node_gateway_healthcheck_peer_count_total counter
node_gateway_healthcheck_peer_count_total{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 6
node_gateway_healthcheck_peer_count_total{endpoint_id="satsuma-erigon-2",url="http://35.171.183.44:8545"} 6







# HELP node_gateway_healthcheck_sync_status Sync status of upstream.
# TYPE node_gateway_healthcheck_sync_status gauge
node_gateway_healthcheck_sync_status{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 0
node_gateway_healthcheck_sync_status{endpoint_id="satsuma-erigon-2",url="http://35.171.183.44:8545"} 0
# HELP node_gateway_healthcheck_sync_status_duration_seconds Latency of sync status requests.
# TYPE node_gateway_healthcheck_sync_status_duration_seconds histogram
node_gateway_healthcheck_sync_status_duration_seconds_bucket{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545",le="0.1"} 4

node_gateway_healthcheck_sync_status_duration_seconds_sum{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 0.7080501670000001
node_gateway_healthcheck_sync_status_duration_seconds_count{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 6

# HELP node_gateway_healthcheck_sync_status_total Total sync status requests made.
# TYPE node_gateway_healthcheck_sync_status_total counter
node_gateway_healthcheck_sync_status_total{endpoint_id="satsuma-erigon-1",url="http://54.146.12.232:8545"} 6
node_gateway_healthcheck_sync_status_total{endpoint_id="satsuma-erigon-2",url="http://35.171.183.44:8545"} 6
```
