### PR TITLE
fix: change health check interval to 5s

### DIFF
--- a/internal/checks/manager.go
+++ b/internal/checks/manager.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	periodicHealthCheckInterval = 1 * time.Second
+	periodicHealthCheckInterval = 5 * time.Second
 )
 
 type UpstreamStatus struct {


### PR DESCRIPTION
# Description
1s too frequent for node providers. The interval should be configurable per upstream.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)


