### PR TITLE
feat: route state-backed requests to archive nodes

### DIFF
--- a/configs/config.sample.yml
+++ b/configs/config.sample.yml
@@ -33,10 +33,12 @@ upstreams:
   #     it quickly updates the gateway with the latest block height. If this
   #     setting is undefined, the gateway will attempt to subscribe to new
   #     heads if the upstream supports it.
+  # nodeType - full or archive
   - id: my-node
     httpURL: "http://12.57.207.168:8545"
     wsURL: "wss://12.57.207.168:8546"
     group: primary
+    nodeType: full
   - id: infura-eth
     httpURL: "https://mainnet.infura.io/v3/${INFURA_API_KEY}"
     wsURL: "wss://mainnet.infura.io/ws/v3/${INFURA_API_KEY}"
@@ -44,9 +46,11 @@ upstreams:
       username: ~
       password: ${INFURA_API_KEY_SECRET}
     group: fallback
+    nodeType: archive
   - id: alchemy-eth
     httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
     wsURL: "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
     healthCheck:
       useWsForBlockHeight: false
     group: fallback
+    nodeType: full

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,12 @@ func (c *UpstreamConfig) isValid(groups []GroupConfig) bool {
 		zap.L().Error("httpUrl cannot be empty", zap.Any("config", c), zap.String("upstreamId", c.ID))
 	}
 
+	if c.NodeType == "" {
+		isValid = false
+
+		zap.L().Error("nodeType cannot be empty", zap.Any("config", c), zap.String("upstreamId", c.ID))
+	}
+
 	if c.HealthCheckConfig.UseWSForBlockHeight != nil && *c.HealthCheckConfig.UseWSForBlockHeight && c.WSURL == "" {
 		isValid = false
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type NodeType string
+
+const (
+	Archive NodeType = "archive"
+	Full    NodeType = "full"
+)
+
 type UpstreamConfig struct {
 	BasicAuthConfig   BasicAuthConfig   `yaml:"basicAuth"`
 	HealthCheckConfig HealthCheckConfig `yaml:"healthCheck"`
@@ -15,6 +22,7 @@ type UpstreamConfig struct {
 	HTTPURL           string            `yaml:"httpURL"`
 	WSURL             string            `yaml:"wsURL"`
 	GroupID           string            `yaml:"group"`
+	NodeType          NodeType          `yaml:"nodeType"`
 }
 
 func (c *UpstreamConfig) isValid(groups []GroupConfig) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -120,10 +120,12 @@ func TestParseConfig_ValidConfig(t *testing.T) {
         healthCheck:
           useWsForBlockHeight: true
         group: primary
+        nodeType: full
       - id: ankr-polygon
         httpURL: "https://rpc.ankr.com/polygon"
         wsURL: "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}"
         group: fallback
+        nodeType: archive
   `
 	configBytes := []byte(config)
 
@@ -142,7 +144,8 @@ func TestParseConfig_ValidConfig(t *testing.T) {
 				HealthCheckConfig: HealthCheckConfig{
 					UseWSForBlockHeight: newBool(true),
 				},
-				GroupID: "primary",
+				GroupID:  "primary",
+				NodeType: Full,
 			},
 			{
 				ID:      "ankr-polygon",
@@ -151,7 +154,8 @@ func TestParseConfig_ValidConfig(t *testing.T) {
 				HealthCheckConfig: HealthCheckConfig{
 					UseWSForBlockHeight: nil,
 				},
-				GroupID: "fallback",
+				GroupID:  "fallback",
+				NodeType: Archive,
 			},
 		},
 		Global: GlobalConfig{

--- a/internal/metadata/request_metadata.go
+++ b/internal/metadata/request_metadata.go
@@ -1,0 +1,5 @@
+package metadata
+
+type RequestMetadata struct {
+	IsStateRequired bool
+}

--- a/internal/metadata/request_metadata_parser.go
+++ b/internal/metadata/request_metadata_parser.go
@@ -1,0 +1,20 @@
+package metadata
+
+import (
+	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
+)
+
+type RequestMetadataParser struct{}
+
+func (p *RequestMetadataParser) Parse(requestBody jsonrpc.RequestBody) RequestMetadata {
+	result := RequestMetadata{}
+
+	switch requestBody.Method {
+	case "eth_getBalance", "eth_getStorageAt", "eth_getTransactionCount", "eth_getCode", "eth_call", "eth_estimateGas":
+		result.IsStateRequired = true
+	default:
+		result.IsStateRequired = false
+	}
+
+	return result
+}

--- a/internal/metadata/request_metadata_parser.go
+++ b/internal/metadata/request_metadata_parser.go
@@ -11,6 +11,7 @@ func (p *RequestMetadataParser) Parse(requestBody jsonrpc.RequestBody) RequestMe
 
 	switch requestBody.Method {
 	case "eth_getBalance", "eth_getStorageAt", "eth_getTransactionCount", "eth_getCode", "eth_call", "eth_estimateGas":
+		// List of state methods: https://ethereum.org/en/developers/docs/apis/json-rpc/#state_methods
 		result.IsStateRequired = true
 	default:
 		result.IsStateRequired = false

--- a/internal/metadata/request_metadata_parser_test.go
+++ b/internal/metadata/request_metadata_parser_test.go
@@ -11,6 +11,7 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 	type args struct {
 		requestBody jsonrpc.RequestBody
 	}
+
 	tests := []struct {
 		name string
 		args args
@@ -21,6 +22,7 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 		{"eth_getBlockByNumber", args{jsonrpc.RequestBody{Method: "eth_getBlockByNumber"}}, RequestMetadata{IsStateRequired: false}},
 		{"eth_getTransactionReceipt", args{jsonrpc.RequestBody{Method: "eth_getTransactionReceipt"}}, RequestMetadata{IsStateRequired: false}},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &RequestMetadataParser{}

--- a/internal/metadata/request_metadata_parser_test.go
+++ b/internal/metadata/request_metadata_parser_test.go
@@ -1,0 +1,30 @@
+package metadata
+
+import (
+	"testing"
+
+	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestMetadataParser_Parse(t *testing.T) {
+	type args struct {
+		requestBody jsonrpc.RequestBody
+	}
+	tests := []struct {
+		name string
+		args args
+		want RequestMetadata
+	}{
+		{"eth_call", args{jsonrpc.RequestBody{Method: "eth_call"}}, RequestMetadata{IsStateRequired: true}},
+		{"eth_getBalance", args{jsonrpc.RequestBody{Method: "eth_getBalance"}}, RequestMetadata{IsStateRequired: true}},
+		{"eth_getBlockByNumber", args{jsonrpc.RequestBody{Method: "eth_getBlockByNumber"}}, RequestMetadata{IsStateRequired: false}},
+		{"eth_getTransactionReceipt", args{jsonrpc.RequestBody{Method: "eth_getTransactionReceipt"}}, RequestMetadata{IsStateRequired: false}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &RequestMetadataParser{}
+			assert.Equalf(t, tt.want, p.Parse(tt.args.requestBody), "Parse(%v)", tt.args.requestBody)
+		})
+	}
+}

--- a/internal/metadata/request_metadata_parser_test.go
+++ b/internal/metadata/request_metadata_parser_test.go
@@ -12,15 +12,25 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 		requestBody jsonrpc.RequestBody
 	}
 
-	tests := []struct {
+	type testArgs struct {
 		name string
 		args args
 		want RequestMetadata
-	}{
-		{"eth_call", args{jsonrpc.RequestBody{Method: "eth_call"}}, RequestMetadata{IsStateRequired: true}},
-		{"eth_getBalance", args{jsonrpc.RequestBody{Method: "eth_getBalance"}}, RequestMetadata{IsStateRequired: true}},
-		{"eth_getBlockByNumber", args{jsonrpc.RequestBody{Method: "eth_getBlockByNumber"}}, RequestMetadata{IsStateRequired: false}},
-		{"eth_getTransactionReceipt", args{jsonrpc.RequestBody{Method: "eth_getTransactionReceipt"}}, RequestMetadata{IsStateRequired: false}},
+	}
+
+	testForMethod := func(methodName string, isStateRequired bool) testArgs {
+		return testArgs{
+			methodName,
+			args{jsonrpc.RequestBody{Method: methodName}},
+			RequestMetadata{IsStateRequired: isStateRequired},
+		}
+	}
+
+	tests := []testArgs{
+		testForMethod("eth_call", true),
+		testForMethod("eth_getBalance", true),
+		testForMethod("eth_getBlockByNumber", false),
+		testForMethod("eth_getTransactionReceipt", false),
 	}
 
 	for _, tt := range tests {

--- a/internal/mocks/RoutingStrategy.go
+++ b/internal/mocks/RoutingStrategy.go
@@ -3,6 +3,7 @@
 package mocks
 
 import (
+	"github.com/satsuma-data/node-gateway/internal/metadata"
 	mock "github.com/stretchr/testify/mock"
 
 	types "github.com/satsuma-data/node-gateway/internal/types"
@@ -22,7 +23,10 @@ func (_m *MockRoutingStrategy) EXPECT() *MockRoutingStrategy_Expecter {
 }
 
 // RouteNextRequest provides a mock function with given fields: upstreamsByPriority
-func (_m *MockRoutingStrategy) RouteNextRequest(upstreamsByPriority types.PriorityToUpstreamsMap) (string, error) {
+func (_m *MockRoutingStrategy) RouteNextRequest(
+	upstreamsByPriority types.PriorityToUpstreamsMap,
+	requestMetadata metadata.RequestMetadata,
+) (string, error) {
 	ret := _m.Called(upstreamsByPriority)
 
 	var r0 string

--- a/internal/route/filtering_strategy.go
+++ b/internal/route/filtering_strategy.go
@@ -2,6 +2,7 @@ package route
 
 import (
 	"github.com/satsuma-data/node-gateway/internal/config"
+	"github.com/satsuma-data/node-gateway/internal/metadata"
 	"github.com/satsuma-data/node-gateway/internal/types"
 	"go.uber.org/zap"
 )
@@ -11,9 +12,12 @@ type FilteringRoutingStrategy struct {
 	BackingStrategy RoutingStrategy
 }
 
-func (s *FilteringRoutingStrategy) RouteNextRequest(upstreamsByPriority types.PriorityToUpstreamsMap) (string, error) {
+func (s *FilteringRoutingStrategy) RouteNextRequest(
+	upstreamsByPriority types.PriorityToUpstreamsMap,
+	requestMetadata metadata.RequestMetadata,
+) (string, error) {
 	filteredUpstreams := s.filter(upstreamsByPriority)
-	return s.BackingStrategy.RouteNextRequest(filteredUpstreams)
+	return s.BackingStrategy.RouteNextRequest(filteredUpstreams, requestMetadata)
 }
 
 func (s *FilteringRoutingStrategy) filter(upstreamsByPriority types.PriorityToUpstreamsMap) types.PriorityToUpstreamsMap {

--- a/internal/route/filtering_strategy.go
+++ b/internal/route/filtering_strategy.go
@@ -16,11 +16,14 @@ func (s *FilteringRoutingStrategy) RouteNextRequest(
 	upstreamsByPriority types.PriorityToUpstreamsMap,
 	requestMetadata metadata.RequestMetadata,
 ) (string, error) {
-	filteredUpstreams := s.filter(upstreamsByPriority)
+	filteredUpstreams := s.filter(upstreamsByPriority, requestMetadata)
 	return s.BackingStrategy.RouteNextRequest(filteredUpstreams, requestMetadata)
 }
 
-func (s *FilteringRoutingStrategy) filter(upstreamsByPriority types.PriorityToUpstreamsMap) types.PriorityToUpstreamsMap {
+func (s *FilteringRoutingStrategy) filter(
+	upstreamsByPriority types.PriorityToUpstreamsMap,
+	requestMetadata metadata.RequestMetadata,
+) types.PriorityToUpstreamsMap {
 	priorityToHealthyUpstreams := make(types.PriorityToUpstreamsMap)
 
 	for priority, upstreamConfigs := range upstreamsByPriority {
@@ -29,7 +32,7 @@ func (s *FilteringRoutingStrategy) filter(upstreamsByPriority types.PriorityToUp
 		filteredUpstreams := make([]*config.UpstreamConfig, 0)
 
 		for _, upstreamConfig := range upstreamConfigs {
-			if s.NodeFilter.Apply(nil, upstreamConfig) {
+			if s.NodeFilter.Apply(requestMetadata, upstreamConfig) {
 				filteredUpstreams = append(filteredUpstreams, upstreamConfig)
 			}
 		}

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -63,9 +63,9 @@ func (f *IsAtMaxHeightForGroup) Apply(_ metadata.RequestMetadata, upstreamConfig
 	return upstreamStatus.BlockHeightCheck.IsPassing(maxHeightForGroup)
 }
 
-type SimpleIsStatePresentFilter struct{}
+type SimpleIsStatePresent struct{}
 
-func (f *SimpleIsStatePresentFilter) Apply(
+func (f *SimpleIsStatePresent) Apply(
 	requestMetadata metadata.RequestMetadata,
 	upstreamConfig *config.UpstreamConfig,
 ) bool {
@@ -107,8 +107,8 @@ func CreateSingleNodeFilter(
 			healthCheckManager: manager,
 			chainMetadataStore: store,
 		}
-	case SimpleIsStatePresent:
-		return &SimpleIsStatePresentFilter{}
+	case SimpleStatePresent:
+		return &SimpleIsStatePresent{}
 	default:
 		panic("Unknown filter type " + filterName + "!")
 	}
@@ -117,8 +117,8 @@ func CreateSingleNodeFilter(
 type NodeFilterType string
 
 const (
-	Healthy              NodeFilterType = "healthy"
-	GlobalMaxHeight      NodeFilterType = "globalMaxHeight"
-	MaxHeightForGroup    NodeFilterType = "maxHeightForGroup"
-	SimpleIsStatePresent NodeFilterType = "simpleIsStatePresent"
+	Healthy            NodeFilterType = "healthy"
+	GlobalMaxHeight    NodeFilterType = "globalMaxHeight"
+	MaxHeightForGroup  NodeFilterType = "maxHeightForGroup"
+	SimpleStatePresent NodeFilterType = "simpleStatePresent"
 )

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -6,19 +6,15 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/metadata"
 )
 
-type RequestMetadata struct {
-	IsStateRequired bool
-}
-
 type NodeFilter interface {
-	Apply(requestMetadata *RequestMetadata, upstreamConfig *config.UpstreamConfig) bool
+	Apply(requestMetadata *metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool
 }
 
 type AndFilter struct {
 	filters []NodeFilter
 }
 
-func (a *AndFilter) Apply(requestMetadata *RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
+func (a *AndFilter) Apply(requestMetadata *metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
 	var result = true
 
 	for filterIndex := range a.filters {
@@ -36,7 +32,7 @@ type IsHealthy struct {
 	healthCheckManager checks.HealthCheckManager
 }
 
-func (f *IsHealthy) Apply(_ *RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
+func (f *IsHealthy) Apply(_ *metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
 	var upstreamStatus = f.healthCheckManager.GetUpstreamStatus(upstreamConfig.ID)
 	return upstreamStatus.PeerCheck.IsPassing() && upstreamStatus.SyncingCheck.IsPassing()
 }
@@ -46,7 +42,7 @@ type IsAtGlobalMaxHeight struct {
 	chainMetadataStore *metadata.ChainMetadataStore
 }
 
-func (f *IsAtGlobalMaxHeight) Apply(_ *RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
+func (f *IsAtGlobalMaxHeight) Apply(_ *metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
 	maxHeight := f.chainMetadataStore.GetGlobalMaxHeight()
 
 	upstreamStatus := f.healthCheckManager.GetUpstreamStatus(upstreamConfig.ID)
@@ -59,7 +55,7 @@ type IsAtMaxHeightForGroup struct {
 	chainMetadataStore *metadata.ChainMetadataStore
 }
 
-func (f *IsAtMaxHeightForGroup) Apply(_ *RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
+func (f *IsAtMaxHeightForGroup) Apply(_ *metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
 	maxHeightForGroup := f.chainMetadataStore.GetMaxHeightForGroup(upstreamConfig.GroupID)
 
 	upstreamStatus := f.healthCheckManager.GetUpstreamStatus(upstreamConfig.ID)
@@ -70,7 +66,7 @@ func (f *IsAtMaxHeightForGroup) Apply(_ *RequestMetadata, upstreamConfig *config
 type SimpleIsStatePresentFilter struct{}
 
 func (f *SimpleIsStatePresentFilter) Apply(
-	requestMetadata *RequestMetadata,
+	requestMetadata *metadata.RequestMetadata,
 	upstreamConfig *config.UpstreamConfig,
 ) bool {
 	if requestMetadata.IsStateRequired {

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -7,14 +7,14 @@ import (
 )
 
 type NodeFilter interface {
-	Apply(requestMetadata *metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool
+	Apply(requestMetadata metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool
 }
 
 type AndFilter struct {
 	filters []NodeFilter
 }
 
-func (a *AndFilter) Apply(requestMetadata *metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
+func (a *AndFilter) Apply(requestMetadata metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
 	var result = true
 
 	for filterIndex := range a.filters {
@@ -42,7 +42,7 @@ type IsAtGlobalMaxHeight struct {
 	chainMetadataStore *metadata.ChainMetadataStore
 }
 
-func (f *IsAtGlobalMaxHeight) Apply(_ *metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
+func (f *IsAtGlobalMaxHeight) Apply(_ metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
 	maxHeight := f.chainMetadataStore.GetGlobalMaxHeight()
 
 	upstreamStatus := f.healthCheckManager.GetUpstreamStatus(upstreamConfig.ID)
@@ -55,7 +55,7 @@ type IsAtMaxHeightForGroup struct {
 	chainMetadataStore *metadata.ChainMetadataStore
 }
 
-func (f *IsAtMaxHeightForGroup) Apply(_ *metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
+func (f *IsAtMaxHeightForGroup) Apply(_ metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
 	maxHeightForGroup := f.chainMetadataStore.GetMaxHeightForGroup(upstreamConfig.GroupID)
 
 	upstreamStatus := f.healthCheckManager.GetUpstreamStatus(upstreamConfig.ID)
@@ -66,7 +66,7 @@ func (f *IsAtMaxHeightForGroup) Apply(_ *metadata.RequestMetadata, upstreamConfi
 type SimpleIsStatePresentFilter struct{}
 
 func (f *SimpleIsStatePresentFilter) Apply(
-	requestMetadata *metadata.RequestMetadata,
+	requestMetadata metadata.RequestMetadata,
 	upstreamConfig *config.UpstreamConfig,
 ) bool {
 	if requestMetadata.IsStateRequired {

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -32,7 +32,7 @@ type IsHealthy struct {
 	healthCheckManager checks.HealthCheckManager
 }
 
-func (f *IsHealthy) Apply(_ *metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
+func (f *IsHealthy) Apply(_ metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
 	var upstreamStatus = f.healthCheckManager.GetUpstreamStatus(upstreamConfig.ID)
 	return upstreamStatus.PeerCheck.IsPassing() && upstreamStatus.SyncingCheck.IsPassing()
 }
@@ -107,6 +107,8 @@ func CreateSingleNodeFilter(
 			healthCheckManager: manager,
 			chainMetadataStore: store,
 		}
+	case SimpleIsStatePresent:
+		return &SimpleIsStatePresentFilter{}
 	default:
 		panic("Unknown filter type " + filterName + "!")
 	}
@@ -115,7 +117,8 @@ func CreateSingleNodeFilter(
 type NodeFilterType string
 
 const (
-	Healthy           NodeFilterType = "healthy"
-	GlobalMaxHeight   NodeFilterType = "globalMaxHeight"
-	MaxHeightForGroup NodeFilterType = "maxHeightForGroup"
+	Healthy              NodeFilterType = "healthy"
+	GlobalMaxHeight      NodeFilterType = "globalMaxHeight"
+	MaxHeightForGroup    NodeFilterType = "maxHeightForGroup"
+	SimpleIsStatePresent NodeFilterType = "simpleIsStatePresent"
 )

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -6,7 +6,9 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/metadata"
 )
 
-type RequestMetadata struct{}
+type RequestMetadata struct {
+	IsStateRequired bool
+}
 
 type NodeFilter interface {
 	Apply(requestMetadata *RequestMetadata, upstreamConfig *config.UpstreamConfig) bool
@@ -63,6 +65,19 @@ func (f *IsAtMaxHeightForGroup) Apply(_ *RequestMetadata, upstreamConfig *config
 	upstreamStatus := f.healthCheckManager.GetUpstreamStatus(upstreamConfig.ID)
 
 	return upstreamStatus.BlockHeightCheck.IsPassing(maxHeightForGroup)
+}
+
+type SimpleIsStatePresentFilter struct{}
+
+func (f *SimpleIsStatePresentFilter) Apply(
+	requestMetadata *RequestMetadata,
+	upstreamConfig *config.UpstreamConfig,
+) bool {
+	if requestMetadata.IsStateRequired {
+		return upstreamConfig.NodeType == config.Archive
+	}
+
+	return true
 }
 
 func CreateNodeFilter(

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -10,13 +10,13 @@ import (
 
 type AlwaysPass struct{}
 
-func (AlwaysPass) Apply(_ *metadata.RequestMetadata, _ *config.UpstreamConfig) bool {
+func (AlwaysPass) Apply(metadata.RequestMetadata, *config.UpstreamConfig) bool {
 	return true
 }
 
 type AlwaysFail struct{}
 
-func (AlwaysFail) Apply(_ *metadata.RequestMetadata, _ *config.UpstreamConfig) bool {
+func (AlwaysFail) Apply(metadata.RequestMetadata, *config.UpstreamConfig) bool {
 	return false
 }
 
@@ -26,7 +26,7 @@ func TestAndFilter_Apply(t *testing.T) {
 	}
 
 	type args struct {
-		requestMetadata *metadata.RequestMetadata
+		requestMetadata metadata.RequestMetadata
 		upstreamConfig  *config.UpstreamConfig
 	}
 

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -25,7 +25,7 @@ func TestAndFilter_Apply(t *testing.T) {
 		filters []NodeFilter
 	}
 
-	type args struct {
+	type args struct { //nolint:govet // field alignment doesn't matter in tests
 		requestMetadata metadata.RequestMetadata
 		upstreamConfig  *config.UpstreamConfig
 	}
@@ -59,11 +59,12 @@ func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {
 	stateMethodMetadata := metadata.RequestMetadata{IsStateRequired: true}
 	nonStateMethodMetadata := metadata.RequestMetadata{IsStateRequired: false}
 
-	type args struct {
+	type args struct { //nolint:govet // field alignment doesn't matter in tests
 		requestMetadata metadata.RequestMetadata
 		upstreamConfig  *config.UpstreamConfig
 	}
-	tests := []struct {
+
+	tests := []struct { //nolint:govet // field alignment doesn't matter in tests
 		name string
 		args args
 		want bool
@@ -73,6 +74,7 @@ func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {
 		{"nonStateMethodFullNode", args{nonStateMethodMetadata, &fullNodeConfig}, true},
 		{"nonStateMethodArchiveNode", args{nonStateMethodMetadata, &archiveNodeConfig}, true},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &SimpleIsStatePresentFilter{}

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -77,7 +77,7 @@ func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := &SimpleIsStatePresentFilter{}
+			f := &SimpleIsStatePresent{}
 			assert.Equalf(t, tt.want, f.Apply(tt.args.requestMetadata, tt.args.upstreamConfig), "Apply(%v, %v)", tt.args.requestMetadata, tt.args.upstreamConfig)
 		})
 	}

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -4,18 +4,19 @@ import (
 	"testing"
 
 	"github.com/satsuma-data/node-gateway/internal/config"
+	"github.com/satsuma-data/node-gateway/internal/metadata"
 	"github.com/stretchr/testify/assert"
 )
 
 type AlwaysPass struct{}
 
-func (AlwaysPass) Apply(_ *RequestMetadata, _ *config.UpstreamConfig) bool {
+func (AlwaysPass) Apply(_ *metadata.RequestMetadata, _ *config.UpstreamConfig) bool {
 	return true
 }
 
 type AlwaysFail struct{}
 
-func (AlwaysFail) Apply(_ *RequestMetadata, _ *config.UpstreamConfig) bool {
+func (AlwaysFail) Apply(_ *metadata.RequestMetadata, _ *config.UpstreamConfig) bool {
 	return false
 }
 
@@ -25,7 +26,7 @@ func TestAndFilter_Apply(t *testing.T) {
 	}
 
 	type args struct {
-		requestMetadata *RequestMetadata
+		requestMetadata *metadata.RequestMetadata
 		upstreamConfig  *config.UpstreamConfig
 	}
 

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -51,3 +51,32 @@ func TestAndFilter_Apply(t *testing.T) {
 		})
 	}
 }
+
+func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {
+	fullNodeConfig := config.UpstreamConfig{NodeType: config.Full}
+	archiveNodeConfig := config.UpstreamConfig{NodeType: config.Archive}
+
+	stateMethodMetadata := metadata.RequestMetadata{IsStateRequired: true}
+	nonStateMethodMetadata := metadata.RequestMetadata{IsStateRequired: false}
+
+	type args struct {
+		requestMetadata metadata.RequestMetadata
+		upstreamConfig  *config.UpstreamConfig
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"stateMethodFullNode", args{stateMethodMetadata, &fullNodeConfig}, false},
+		{"stateMethodArchiveNode", args{stateMethodMetadata, &archiveNodeConfig}, true},
+		{"nonStateMethodFullNode", args{nonStateMethodMetadata, &fullNodeConfig}, true},
+		{"nonStateMethodArchiveNode", args{nonStateMethodMetadata, &archiveNodeConfig}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &SimpleIsStatePresentFilter{}
+			assert.Equalf(t, tt.want, f.Apply(tt.args.requestMetadata, tt.args.upstreamConfig), "Apply(%v, %v)", tt.args.requestMetadata, tt.args.upstreamConfig)
+		})
+	}
+}

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -99,6 +99,7 @@ func (r *SimpleRouter) Route(
 ) (*jsonrpc.ResponseBody, *http.Response, error) {
 	requestMetadata := r.metadataParser.Parse(requestBody)
 	id, err := r.routingStrategy.RouteNextRequest(r.priorityToUpstreams, requestMetadata)
+
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrNoHealthyUpstreams):

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -39,6 +39,7 @@ type SimpleRouter struct {
 	requestExecutor    RequestExecutor
 	// Map from Priority => UpstreamIDs
 	priorityToUpstreams types.PriorityToUpstreamsMap
+	metadataParser      metadata.RequestMetadataParser
 	upstreamConfigs     []config.UpstreamConfig
 }
 
@@ -56,6 +57,7 @@ func NewRouter(
 		priorityToUpstreams: groupUpstreamsByPriority(upstreamConfigs, groupConfigs),
 		routingStrategy:     routingStrategy,
 		requestExecutor:     RequestExecutor{httpClient: &http.Client{}},
+		metadataParser:      metadata.RequestMetadataParser{},
 	}
 
 	return r
@@ -95,6 +97,7 @@ func (r *SimpleRouter) Route(
 	ctx context.Context,
 	requestBody jsonrpc.RequestBody,
 ) (*jsonrpc.ResponseBody, *http.Response, error) {
+	_ = r.metadataParser.Parse(requestBody)
 	id, err := r.routingStrategy.RouteNextRequest(r.priorityToUpstreams)
 	if err != nil {
 		switch {

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -97,8 +97,8 @@ func (r *SimpleRouter) Route(
 	ctx context.Context,
 	requestBody jsonrpc.RequestBody,
 ) (*jsonrpc.ResponseBody, *http.Response, error) {
-	_ = r.metadataParser.Parse(requestBody)
-	id, err := r.routingStrategy.RouteNextRequest(r.priorityToUpstreams)
+	requestMetadata := r.metadataParser.Parse(requestBody)
+	id, err := r.routingStrategy.RouteNextRequest(r.priorityToUpstreams, requestMetadata)
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrNoHealthyUpstreams):

--- a/internal/route/routing_strategy.go
+++ b/internal/route/routing_strategy.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"sync/atomic"
 
+	"github.com/satsuma-data/node-gateway/internal/metadata"
 	"github.com/satsuma-data/node-gateway/internal/types"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
@@ -14,7 +15,10 @@ import (
 //go:generate mockery --output ../mocks --name RoutingStrategy --structname MockRoutingStrategy --with-expecter
 type RoutingStrategy interface {
 	// Returns the next UpstreamID a request should route to.
-	RouteNextRequest(upstreamsByPriority types.PriorityToUpstreamsMap) (string, error)
+	RouteNextRequest(
+		upstreamsByPriority types.PriorityToUpstreamsMap,
+		requestMetadata metadata.RequestMetadata,
+	) (string, error)
 }
 type PriorityRoundRobinStrategy struct {
 	counter uint64
@@ -28,7 +32,10 @@ func NewPriorityRoundRobinStrategy() *PriorityRoundRobinStrategy {
 
 var ErrNoHealthyUpstreams = errors.New("no healthy upstreams")
 
-func (s *PriorityRoundRobinStrategy) RouteNextRequest(upstreamsByPriority types.PriorityToUpstreamsMap) (string, error) {
+func (s *PriorityRoundRobinStrategy) RouteNextRequest(
+	upstreamsByPriority types.PriorityToUpstreamsMap,
+	_ metadata.RequestMetadata,
+) (string, error) {
 	prioritySorted := maps.Keys(upstreamsByPriority)
 	sort.Ints(prioritySorted)
 

--- a/internal/route/routing_strategy_test.go
+++ b/internal/route/routing_strategy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/satsuma-data/node-gateway/internal/config"
+	"github.com/satsuma-data/node-gateway/internal/metadata"
 	"github.com/satsuma-data/node-gateway/internal/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,10 +19,10 @@ func TestPriorityStrategy_HighPriority(t *testing.T) {
 	strategy := NewPriorityRoundRobinStrategy()
 
 	for i := 0; i < 10; i++ {
-		firstUpstreamID, _ := strategy.RouteNextRequest(upstreams)
+		firstUpstreamID, _ := strategy.RouteNextRequest(upstreams, metadata.RequestMetadata{})
 		assert.Equal(t, "something-else", firstUpstreamID)
 
-		secondUpstreamID, _ := strategy.RouteNextRequest(upstreams)
+		secondUpstreamID, _ := strategy.RouteNextRequest(upstreams, metadata.RequestMetadata{})
 		assert.Equal(t, "geth", secondUpstreamID)
 	}
 }
@@ -41,10 +42,10 @@ func TestPriorityStrategy_LowerPriority(t *testing.T) {
 	strategy := NewPriorityRoundRobinStrategy()
 
 	for i := 0; i < 10; i++ {
-		firstUpstreamID, _ := strategy.RouteNextRequest(upstreams)
+		firstUpstreamID, _ := strategy.RouteNextRequest(upstreams, metadata.RequestMetadata{})
 		assert.Equal(t, "fallback2", firstUpstreamID)
 
-		secondUpstreamID, _ := strategy.RouteNextRequest(upstreams)
+		secondUpstreamID, _ := strategy.RouteNextRequest(upstreams, metadata.RequestMetadata{})
 		assert.Equal(t, "fallback1", secondUpstreamID)
 	}
 }
@@ -58,7 +59,7 @@ func TestPriorityStrategy_NoUpstreams(t *testing.T) {
 	strategy := NewPriorityRoundRobinStrategy()
 
 	for i := 0; i < 10; i++ {
-		upstreamID, err := strategy.RouteNextRequest(upstreams)
+		upstreamID, err := strategy.RouteNextRequest(upstreams, metadata.RequestMetadata{})
 		assert.Equal(t, "", upstreamID)
 		assert.True(t, errors.Is(err, ErrNoHealthyUpstreams))
 	}

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -68,7 +68,7 @@ func wireRouter(config conf.Config) route.Router {
 	ticker := time.NewTicker(checks.PeriodicHealthCheckInterval)
 	healthCheckManager := checks.NewHealthCheckManager(client.NewEthClient, config.Upstreams, chainMetadataStore, ticker)
 
-	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.SimpleIsStatePresent}
+	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.SimpleStatePresent}
 	nodeFilter := route.CreateNodeFilter(enabledNodeFilters, healthCheckManager, chainMetadataStore)
 	routingStrategy := route.FilteringRoutingStrategy{
 		NodeFilter:      nodeFilter,

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -68,7 +68,8 @@ func wireRouter(config conf.Config) route.Router {
 	ticker := time.NewTicker(checks.PeriodicHealthCheckInterval)
 	healthCheckManager := checks.NewHealthCheckManager(client.NewEthClient, config.Upstreams, chainMetadataStore, ticker)
 
-	nodeFilter := route.CreateNodeFilter([]route.NodeFilterType{route.Healthy, route.MaxHeightForGroup}, healthCheckManager, chainMetadataStore)
+	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.SimpleIsStatePresent}
+	nodeFilter := route.CreateNodeFilter(enabledNodeFilters, healthCheckManager, chainMetadataStore)
 	routingStrategy := route.FilteringRoutingStrategy{
 		NodeFilter:      nodeFilter,
 		BackingStrategy: route.NewPriorityRoundRobinStrategy(),


### PR DESCRIPTION
# Description

- Added a new NodeFilter to route state RPC methods only to archive nodes.
- Added `nodeType` to the `UpstreamConfig` so that we know which nodes maintain full historic state.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Unit tests for the `RequestMetadataParser` and `SimpleIsStatePresentFilter`.