### PR TITLE
test: add end-to-end tests using fake upstreams

### DIFF
--- a/internal/checks/manager.go
+++ b/internal/checks/manager.go
@@ -3,6 +3,7 @@ package checks
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/satsuma-data/node-gateway/internal/types"
@@ -20,6 +21,7 @@ const (
 //go:generate mockery --output ../mocks --name HealthCheckManager --with-expecter
 type HealthCheckManager interface {
 	StartHealthChecks()
+	IsInitialized() bool
 	GetUpstreamStatus(upstreamID string) *types.UpstreamStatus
 }
 
@@ -36,6 +38,7 @@ type healthCheckManager struct {
 	blockHeightObserver BlockHeightObserver
 	healthCheckTicker   *time.Ticker
 	configs             []conf.UpstreamConfig
+	isInitialized       atomic.Bool
 }
 
 func NewHealthCheckManager(
@@ -175,4 +178,10 @@ func (h *healthCheckManager) runChecksOnce() {
 	}
 
 	wg.Wait()
+
+	h.isInitialized.Store(true)
+}
+
+func (h *healthCheckManager) IsInitialized() bool {
+	return h.isInitialized.Load()
 }

--- a/internal/mocks/HealthCheckManager.go
+++ b/internal/mocks/HealthCheckManager.go
@@ -59,6 +59,42 @@ func (_c *HealthCheckManager_GetUpstreamStatus_Call) Return(_a0 *types.UpstreamS
 	return _c
 }
 
+// IsInitialized provides a mock function with given fields:
+func (_m *HealthCheckManager) IsInitialized() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// HealthCheckManager_IsInitialized_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsInitialized'
+type HealthCheckManager_IsInitialized_Call struct {
+	*mock.Call
+}
+
+// IsInitialized is a helper method to define mock.On call
+func (_e *HealthCheckManager_Expecter) IsInitialized() *HealthCheckManager_IsInitialized_Call {
+	return &HealthCheckManager_IsInitialized_Call{Call: _e.mock.On("IsInitialized")}
+}
+
+func (_c *HealthCheckManager_IsInitialized_Call) Run(run func()) *HealthCheckManager_IsInitialized_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *HealthCheckManager_IsInitialized_Call) Return(_a0 bool) *HealthCheckManager_IsInitialized_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
 // StartHealthChecks provides a mock function with given fields:
 func (_m *HealthCheckManager) StartHealthChecks() {
 	_m.Called()

--- a/internal/mocks/Router.go
+++ b/internal/mocks/Router.go
@@ -15,6 +15,20 @@ type Router struct {
 	mock.Mock
 }
 
+// IsInitialized provides a mock function with given fields:
+func (_m *Router) IsInitialized() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // Route provides a mock function with given fields: ctx, requestBody
 func (_m *Router) Route(ctx context.Context, requestBody jsonrpc.RequestBody) (*jsonrpc.ResponseBody, *http.Response, error) {
 	ret := _m.Called(ctx, requestBody)

--- a/internal/mocks/RoutingStrategy.go
+++ b/internal/mocks/RoutingStrategy.go
@@ -3,7 +3,7 @@
 package mocks
 
 import (
-	"github.com/satsuma-data/node-gateway/internal/metadata"
+	metadata "github.com/satsuma-data/node-gateway/internal/metadata"
 	mock "github.com/stretchr/testify/mock"
 
 	types "github.com/satsuma-data/node-gateway/internal/types"
@@ -22,23 +22,20 @@ func (_m *MockRoutingStrategy) EXPECT() *MockRoutingStrategy_Expecter {
 	return &MockRoutingStrategy_Expecter{mock: &_m.Mock}
 }
 
-// RouteNextRequest provides a mock function with given fields: upstreamsByPriority
-func (_m *MockRoutingStrategy) RouteNextRequest(
-	upstreamsByPriority types.PriorityToUpstreamsMap,
-	requestMetadata metadata.RequestMetadata,
-) (string, error) {
-	ret := _m.Called(upstreamsByPriority)
+// RouteNextRequest provides a mock function with given fields: upstreamsByPriority, requestMetadata
+func (_m *MockRoutingStrategy) RouteNextRequest(upstreamsByPriority types.PriorityToUpstreamsMap, requestMetadata metadata.RequestMetadata) (string, error) {
+	ret := _m.Called(upstreamsByPriority, requestMetadata)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(types.PriorityToUpstreamsMap) string); ok {
-		r0 = rf(upstreamsByPriority)
+	if rf, ok := ret.Get(0).(func(types.PriorityToUpstreamsMap, metadata.RequestMetadata) string); ok {
+		r0 = rf(upstreamsByPriority, requestMetadata)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(types.PriorityToUpstreamsMap) error); ok {
-		r1 = rf(upstreamsByPriority)
+	if rf, ok := ret.Get(1).(func(types.PriorityToUpstreamsMap, metadata.RequestMetadata) error); ok {
+		r1 = rf(upstreamsByPriority, requestMetadata)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -53,13 +50,14 @@ type MockRoutingStrategy_RouteNextRequest_Call struct {
 
 // RouteNextRequest is a helper method to define mock.On call
 //   - upstreamsByPriority types.PriorityToUpstreamsMap
-func (_e *MockRoutingStrategy_Expecter) RouteNextRequest(upstreamsByPriority interface{}) *MockRoutingStrategy_RouteNextRequest_Call {
-	return &MockRoutingStrategy_RouteNextRequest_Call{Call: _e.mock.On("RouteNextRequest", upstreamsByPriority)}
+//   - requestMetadata metadata.RequestMetadata
+func (_e *MockRoutingStrategy_Expecter) RouteNextRequest(upstreamsByPriority interface{}, requestMetadata interface{}) *MockRoutingStrategy_RouteNextRequest_Call {
+	return &MockRoutingStrategy_RouteNextRequest_Call{Call: _e.mock.On("RouteNextRequest", upstreamsByPriority, requestMetadata)}
 }
 
-func (_c *MockRoutingStrategy_RouteNextRequest_Call) Run(run func(upstreamsByPriority types.PriorityToUpstreamsMap)) *MockRoutingStrategy_RouteNextRequest_Call {
+func (_c *MockRoutingStrategy_RouteNextRequest_Call) Run(run func(upstreamsByPriority types.PriorityToUpstreamsMap, requestMetadata metadata.RequestMetadata)) *MockRoutingStrategy_RouteNextRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(types.PriorityToUpstreamsMap))
+		run(args[0].(types.PriorityToUpstreamsMap), args[1].(metadata.RequestMetadata))
 	})
 	return _c
 }

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -29,6 +29,7 @@ import (
 //go:generate mockery --output ../mocks --name Router
 type Router interface {
 	Start()
+	IsInitialized() bool
 	Route(ctx context.Context, requestBody jsonrpc.RequestBody) (*jsonrpc.ResponseBody, *http.Response, error)
 }
 
@@ -91,6 +92,10 @@ func groupUpstreamsByPriority(
 func (r *SimpleRouter) Start() {
 	r.chainMetadataStore.Start()
 	r.healthCheckManager.StartHealthChecks()
+}
+
+func (r *SimpleRouter) IsInitialized() bool {
+	return r.healthCheckManager.IsInitialized()
 }
 
 func (r *SimpleRouter) Route(

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -31,7 +31,7 @@ func TestRouter_NoHealthyUpstreams(t *testing.T) {
 	}
 
 	routingStrategy := mocks.NewMockRoutingStrategy(t)
-	routingStrategy.EXPECT().RouteNextRequest(mock.Anything).Return("", ErrNoHealthyUpstreams)
+	routingStrategy.EXPECT().RouteNextRequest(mock.Anything, mock.Anything).Return("", ErrNoHealthyUpstreams)
 
 	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, routingStrategy)
 	router.(*SimpleRouter).healthCheckManager = managerMock
@@ -62,7 +62,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 	httpClientMock.On("Do", mock.Anything).Return(httpResp, nil)
 
 	routingStrategyMock := mocks.NewMockRoutingStrategy(t)
-	routingStrategyMock.EXPECT().RouteNextRequest(mock.Anything).Return("erigon", nil)
+	routingStrategyMock.EXPECT().RouteNextRequest(mock.Anything, mock.Anything).Return("erigon", nil)
 
 	gethConfig := config.UpstreamConfig{
 		ID:      "geth",
@@ -120,7 +120,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 		0: {&gethConfig},
 		1: {&erigonConfig},
 		2: {&openEthConfig, &somethingElseConfig},
-	})
+	}, metadata.RequestMetadata{})
 	assert.Equal(t, "erigonURL", httpClientMock.Calls[0].Arguments[0].(*http.Request).URL.Path)
 }
 
@@ -135,7 +135,7 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 	httpClientMock.On("Do", mock.Anything).Return(httpResp, nil)
 
 	routingStrategyMock := mocks.NewMockRoutingStrategy(t)
-	routingStrategyMock.EXPECT().RouteNextRequest(mock.Anything).Return("erigon", nil)
+	routingStrategyMock.EXPECT().RouteNextRequest(mock.Anything, mock.Anything).Return("erigon", nil)
 
 	gethConfig := config.UpstreamConfig{
 		ID:      "geth",
@@ -163,6 +163,6 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 	assert.NotNil(t, "hello", jsonRcpResp.Result)
 	routingStrategyMock.AssertCalled(t, "RouteNextRequest", types.PriorityToUpstreamsMap{
 		0: {&gethConfig, &erigonConfig},
-	})
+	}, metadata.RequestMetadata{IsStateRequired: false})
 	assert.Equal(t, "erigonURL", httpClientMock.Calls[0].Arguments[0].(*http.Request).URL.Path)
 }

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -98,7 +98,7 @@ func (h *HealthCheckHandler) ServeHTTP(writer http.ResponseWriter, _ *http.Reque
 	if h.router.IsInitialized() {
 		respondRaw(writer, []byte("OK"), http.StatusOK)
 	} else {
-		respondRaw(writer, []byte("Starting"), http.StatusOK)
+		respondRaw(writer, []byte("Starting up"), http.StatusServiceUnavailable)
 	}
 }
 

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/satsuma-data/node-gateway/internal/config"
+	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSyncingThenNotSyncing(t *testing.T) {
+	upstreamConfigs := []config.UpstreamConfig{
+		{ID: "testNode"},
+	}
+	//chainMetadataStore := metadata.NewChainMetadataStore()
+	//ethClientGetter := client.NewEthClient
+	//healthCheckManager := checks.NewHealthCheckManager(ethClientGetter, upstreamConfigs, chainMetadataStore, time.NewTicker(checks.PeriodicHealthCheckInterval))
+	//enabledNodeFilters := []route.NodeFilterType{route.IsHealthy, route.MaxHeightForGroup, route.SimpleIsStatePresent}
+	//nodeFilter := route.CreateNodeFilter(enabledNodeFilters, healthCheckManager, chainMetadataStore)
+	//routingStrategy := route.FilteringRoutingStrategy{
+	//	NodeFilter:      nodeFilter,
+	//	BackingStrategy: route.NewPriorityRoundRobinStrategy(),
+	//}
+	//router := route.NewRouter(upstreamConfigs, nil, chainMetadataStore, healthCheckManager, &routingStrategy)
+
+	//router := mocks.NewRouter(t)
+	undecodableContent := []byte("content")
+
+	//router.On("Route", mock.Anything, mock.Anything).
+	//	Return(nil, nil, jsonrpc.DecodeError{Err: errors.New("error decoding"), Content: undecodableContent})
+
+	//handler := &RPCHandler{router: router}
+
+	conf := config.Config{
+		Upstreams: upstreamConfigs,
+		Groups:    nil,
+		Global:    config.GlobalConfig{},
+	}
+
+	router := wireRouter(conf)
+	router.Start()
+	handler := &RPCHandler{
+		router: router,
+	}
+	//server := NewRPCServer(conf)
+	//go func() {
+	//	server.Start()
+	//}()
+	//handler := server.httpServer
+
+	emptyJSONBody, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "eth_blockNumber",
+		"params":  nil,
+		"id":      1,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(emptyJSONBody))
+	req.Header.Add("Content-Type", "application/json")
+
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	result := recorder.Result()
+	defer result.Body.Close()
+
+	_, _ = jsonrpc.DecodeResponseBody(result)
+
+	assert.Equal(t, http.StatusOK, result.StatusCode)
+	body, _ := io.ReadAll(result.Body)
+	assert.Equal(t, undecodableContent, body)
+}

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -152,6 +152,8 @@ func setUpHealthyUpstream(
 		requestBody, err := jsonrpc.DecodeRequestBody(request)
 		assert.NoError(t, err)
 
+		latestBlockNumber := int64(1000)
+
 		switch requestBody.Method {
 		case "eth_syncing":
 			body := jsonrpc.ResponseBody{Result: false}
@@ -164,14 +166,14 @@ func setUpHealthyUpstream(
 		case "eth_getBlockByNumber":
 			body := jsonrpc.ResponseBody{
 				Result: types.Header{
-					Number:     big.NewInt(1000),
+					Number:     big.NewInt(latestBlockNumber),
 					Difficulty: big.NewInt(0),
 				},
 			}
 			writeResponseBody(t, writer, body)
 
 		case "eth_blockNumber":
-			body := jsonrpc.ResponseBody{Result: hexutil.Uint64(1000)}
+			body := jsonrpc.ResponseBody{Result: hexutil.Uint64(latestBlockNumber)}
 			writeResponseBody(t, writer, body)
 
 		default:

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -78,7 +78,10 @@ func setUpHealthyUpstream(t *testing.T) *httptest.Server {
 
 		case "eth_getBlockByNumber":
 			body := jsonrpc.ResponseBody{
-				Result: types.Header{Number: big.NewInt(1000)},
+				Result: types.Header{
+					Number:     big.NewInt(1000),
+					Difficulty: big.NewInt(0),
+				},
 			}
 			writeResponseBody(t, writer, body)
 


### PR DESCRIPTION
# Description

This PR adds basic support for running end-to-end tests that cover the whole routing. It uses in-process servers from the `net/http/httptest` package to bring up fake upstreams, and returns legitimately-looking responses to health check requests. Each test can then configure additional handlers for other RPC methods and check that they are routed as expected.

Notable changes:
1. **I added `IsInitialized` methods to `Router` and `HealthCheckManager`.** I needed a way to confirm that the gateway is fully up and running - in particular, that at least one iteration of the health checks has already executed. Without this, we can't be sure if the behaviour we're testing actually respects the health checks.
2. **I changed the `/health` endpoint to reflect the above.** I thought I was going to need that for the test, but I realized I can directly poll on the `router` instead. However, this still seemed like the correct thing to do - for example, if I'm doing a blue-green deploy, I want to make sure that my newly deployed gateway instance is fully up and running before I redirect traffic to it. The previous health check didn't support this.
3. **Added two test cases for starters - one healthy node; and full vs archive depending on method.** The first one is a nice sanity check that everything works, and is also a simple example of how to get started writing new e2e tests. The second one tests the behaviour I added most recently.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)
- [x] 🚨 Tests

# How Has This Been Tested?

Added new tests and confirmed they pass (and also confirmed that they break accordingly when I break the underlying behaviour).
