### PR TITLE
feat: route to nodes even if slightly behind max height

### DIFF
--- a/configs/config.sample.yml
+++ b/configs/config.sample.yml
@@ -1,6 +1,11 @@
 global:
   port: 8080
 
+routing:
+  # Number of blocks a node can be behind the max known height and
+  # still get requests routed to it.
+  maxBlocksBehind: 10
+
 # (Optional) List of upstream node groups.
 # If defined, all upstreams must define group membership via the `group` field.
 groups:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,10 +114,15 @@ type GlobalConfig struct {
 	Port int `yaml:"port"`
 }
 
+type RoutingConfig struct {
+	MaxBlocksBehind int `yaml:"maxBlocksBehind"`
+}
+
 type Config struct {
 	Upstreams []UpstreamConfig
 	Groups    []GroupConfig
 	Global    GlobalConfig
+	Routing   RoutingConfig
 }
 
 func LoadConfig(configFilePath string) (Config, error) {

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -6,6 +6,10 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/metadata"
 )
 
+const (
+	MaxAllowedBlocksBehindHead = 10
+)
+
 type NodeFilter interface {
 	Apply(requestMetadata metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool
 }
@@ -37,17 +41,21 @@ func (f *IsHealthy) Apply(_ metadata.RequestMetadata, upstreamConfig *config.Ups
 	return upstreamStatus.PeerCheck.IsPassing() && upstreamStatus.SyncingCheck.IsPassing()
 }
 
-type IsAtGlobalMaxHeight struct {
+type IsCloseToGlobalMaxHeight struct {
 	healthCheckManager checks.HealthCheckManager
 	chainMetadataStore *metadata.ChainMetadataStore
+	maxBlocksBehind    uint64
 }
 
-func (f *IsAtGlobalMaxHeight) Apply(_ metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
+func (f *IsCloseToGlobalMaxHeight) Apply(_ metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
 	maxHeight := f.chainMetadataStore.GetGlobalMaxHeight()
 
 	upstreamStatus := f.healthCheckManager.GetUpstreamStatus(upstreamConfig.ID)
 
-	return upstreamStatus.BlockHeightCheck.IsPassing(maxHeight)
+	checkIsHealthy := upstreamStatus.BlockHeightCheck.GetError() == nil
+	isClose := upstreamStatus.BlockHeightCheck.GetBlockHeight()+f.maxBlocksBehind >= maxHeight
+
+	return checkIsHealthy && isClose
 }
 
 type IsAtMaxHeightForGroup struct {
@@ -98,9 +106,16 @@ func CreateSingleNodeFilter(
 	case Healthy:
 		return &IsHealthy{manager}
 	case GlobalMaxHeight:
-		return &IsAtGlobalMaxHeight{
+		return &IsCloseToGlobalMaxHeight{
 			healthCheckManager: manager,
 			chainMetadataStore: store,
+			maxBlocksBehind:    0,
+		}
+	case NearGlobalMaxHeight:
+		return &IsCloseToGlobalMaxHeight{
+			healthCheckManager: manager,
+			chainMetadataStore: store,
+			maxBlocksBehind:    MaxAllowedBlocksBehindHead,
 		}
 	case MaxHeightForGroup:
 		return &IsAtMaxHeightForGroup{
@@ -117,8 +132,9 @@ func CreateSingleNodeFilter(
 type NodeFilterType string
 
 const (
-	Healthy            NodeFilterType = "healthy"
-	GlobalMaxHeight    NodeFilterType = "globalMaxHeight"
-	MaxHeightForGroup  NodeFilterType = "maxHeightForGroup"
-	SimpleStatePresent NodeFilterType = "simpleStatePresent"
+	Healthy             NodeFilterType = "healthy"
+	GlobalMaxHeight     NodeFilterType = "globalMaxHeight"
+	NearGlobalMaxHeight NodeFilterType = "nearGlobalMaxHeight"
+	MaxHeightForGroup   NodeFilterType = "maxHeightForGroup"
+	SimpleStatePresent  NodeFilterType = "simpleStatePresent"
 )

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -71,7 +71,7 @@ func wireRouter(config conf.Config) route.Router {
 	ticker := time.NewTicker(checks.PeriodicHealthCheckInterval)
 	healthCheckManager := checks.NewHealthCheckManager(client.NewEthClient, config.Upstreams, chainMetadataStore, ticker)
 
-	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.SimpleStatePresent}
+	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.SimpleStatePresent, route.NearGlobalMaxHeight}
 	nodeFilter := route.CreateNodeFilter(enabledNodeFilters, healthCheckManager, chainMetadataStore)
 	routingStrategy := route.FilteringRoutingStrategy{
 		NodeFilter:      nodeFilter,

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -72,7 +72,7 @@ func wireRouter(config conf.Config) route.Router {
 	healthCheckManager := checks.NewHealthCheckManager(client.NewEthClient, config.Upstreams, chainMetadataStore, ticker)
 
 	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.SimpleStatePresent, route.NearGlobalMaxHeight}
-	nodeFilter := route.CreateNodeFilter(enabledNodeFilters, healthCheckManager, chainMetadataStore)
+	nodeFilter := route.CreateNodeFilter(enabledNodeFilters, healthCheckManager, chainMetadataStore, &config.Routing)
 	routingStrategy := route.FilteringRoutingStrategy{
 		NodeFilter:      nodeFilter,
 		BackingStrategy: route.NewPriorityRoundRobinStrategy(),


### PR DESCRIPTION
# Description

We want to be able to tolerate some lag in certain situations. For example, we might want to favour our own node over a node provider even if we're slightly behind head. This PR keeps routing to nodes as long as they are within 10 blocks of the max height.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Added unit tests for new filter.