### PR TITLE
feat: add debug logging when NodeFilters fail

### DIFF
--- a/internal/route/filtering_strategy.go
+++ b/internal/route/filtering_strategy.go
@@ -32,7 +32,7 @@ func (s *FilteringRoutingStrategy) filter(
 		filteredUpstreams := make([]*config.UpstreamConfig, 0)
 
 		for _, upstreamConfig := range upstreamConfigs {
-			ok, _ := s.NodeFilter.Apply(requestMetadata, upstreamConfig)
+			ok := s.NodeFilter.Apply(requestMetadata, upstreamConfig)
 			if ok {
 				filteredUpstreams = append(filteredUpstreams, upstreamConfig)
 			}

--- a/internal/route/filtering_strategy.go
+++ b/internal/route/filtering_strategy.go
@@ -32,7 +32,8 @@ func (s *FilteringRoutingStrategy) filter(
 		filteredUpstreams := make([]*config.UpstreamConfig, 0)
 
 		for _, upstreamConfig := range upstreamConfigs {
-			if s.NodeFilter.Apply(requestMetadata, upstreamConfig) {
+			ok, _ := s.NodeFilter.Apply(requestMetadata, upstreamConfig)
+			if ok {
 				filteredUpstreams = append(filteredUpstreams, upstreamConfig)
 			}
 		}

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -14,7 +14,8 @@ type NodeFilter interface {
 }
 
 type AndFilter struct {
-	filters []NodeFilter
+	filters    []NodeFilter
+	isTopLevel bool
 }
 
 func (a *AndFilter) Apply(requestMetadata metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
@@ -30,7 +31,7 @@ func (a *AndFilter) Apply(requestMetadata metadata.RequestMetadata, upstreamConf
 		}
 	}
 
-	if result {
+	if result && a.isTopLevel {
 		zap.L().Debug("Upstream passed all filters for request.", zap.String("upstreamID", upstreamConfig.ID), zap.Any("requestMetadata", requestMetadata))
 	}
 
@@ -171,7 +172,7 @@ func CreateNodeFilter(
 		filters[i] = CreateSingleNodeFilter(filterNames[i], manager, store, routingConfig)
 	}
 
-	return &AndFilter{filters}
+	return &AndFilter{filters, true}
 }
 
 func CreateSingleNodeFilter(

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -32,7 +32,7 @@ func (a *AndFilter) Apply(requestMetadata metadata.RequestMetadata, upstreamConf
 	}
 
 	if result && a.isTopLevel {
-		zap.L().Debug("Upstream passed all filters for request.", zap.String("upstreamID", upstreamConfig.ID), zap.Any("requestMetadata", requestMetadata))
+		zap.L().Debug("Upstream passed all filters for request.", zap.String("upstreamID", upstreamConfig.ID), zap.Any("RequestMetadata", requestMetadata))
 	}
 
 	return result
@@ -155,7 +155,13 @@ func (f *SimpleIsStatePresent) Apply(
 	upstreamConfig *config.UpstreamConfig,
 ) bool {
 	if requestMetadata.IsStateRequired {
-		return upstreamConfig.NodeType == config.Archive
+		if upstreamConfig.NodeType == config.Archive {
+			return true
+		}
+
+		zap.L().Debug("Upstream is not an archive node but state is required!", zap.String("UpstreamID", upstreamConfig.ID), zap.Any("RequestMetadata", requestMetadata))
+
+		return false
 	}
 
 	return true

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -119,7 +119,7 @@ func (f *IsCloseToGlobalMaxHeight) Apply(
 		return true
 	}
 
-	zap.L().Debug("Upstream too far behind global max height! UpstreamHeight: %d, MaxHeight: %d", zap.Uint64("UpstreamHeight", upstreamHeight), zap.Uint64("MaxHeight", maxHeight))
+	zap.L().Debug("Upstream too far behind global max height!", zap.Uint64("UpstreamHeight", upstreamHeight), zap.Uint64("MaxHeight", maxHeight))
 
 	return false
 }

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -12,14 +12,14 @@ import (
 
 type AlwaysPass struct{}
 
-func (AlwaysPass) Apply(metadata.RequestMetadata, *config.UpstreamConfig) (bool, error) {
-	return true, nil
+func (AlwaysPass) Apply(metadata.RequestMetadata, *config.UpstreamConfig) bool {
+	return true
 }
 
 type AlwaysFail struct{}
 
-func (AlwaysFail) Apply(metadata.RequestMetadata, *config.UpstreamConfig) (bool, error) {
-	return false, nil
+func (AlwaysFail) Apply(metadata.RequestMetadata, *config.UpstreamConfig) bool {
+	return false
 }
 
 func TestAndFilter_Apply(t *testing.T) {
@@ -50,7 +50,7 @@ func TestAndFilter_Apply(t *testing.T) {
 			a := &AndFilter{
 				filters: tt.fields.filters,
 			}
-			ok, _ := a.Apply(tt.args.requestMetadata, tt.args.upstreamConfig)
+			ok := a.Apply(tt.args.requestMetadata, tt.args.upstreamConfig)
 			assert.Equalf(t, tt.want, ok, "Apply(%v, %v)", tt.args.requestMetadata, tt.args.upstreamConfig)
 		})
 	}
@@ -81,15 +81,15 @@ func TestIsCloseToGlobalMaxHeight_Apply(t *testing.T) {
 	blockHeightCheck.EXPECT().GetError().Return(nil)
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(85).Once()
-	ok, _ := filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
+	ok := filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
 	assert.False(t, ok)
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(91).Once()
-	ok, _ = filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
+	ok = filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
 	assert.True(t, ok)
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(99).Once()
-	ok, _ = filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
+	ok = filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
 	assert.True(t, ok)
 }
 
@@ -119,7 +119,7 @@ func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &SimpleIsStatePresent{}
-			ok, _ := f.Apply(tt.args.requestMetadata, tt.args.upstreamConfig)
+			ok := f.Apply(tt.args.requestMetadata, tt.args.upstreamConfig)
 			assert.Equalf(t, tt.want, ok, "Apply(%v, %v)", tt.args.requestMetadata, tt.args.upstreamConfig)
 		})
 	}

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -82,22 +82,13 @@ func TestIsCloseToGlobalMaxHeight_Apply(t *testing.T) {
 	blockHeightCheck.EXPECT().GetError().Return(nil)
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(85).Once()
-
-	ok := filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
-
-	assert.False(t, ok)
+	assert.False(t, filter.Apply(metadata.RequestMetadata{}, upstreamConfig))
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(91).Once()
-
-	ok = filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
-
-	assert.True(t, ok)
+	assert.True(t, filter.Apply(metadata.RequestMetadata{}, upstreamConfig))
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(99).Once()
-
-	ok = filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
-
-	assert.True(t, ok)
+	assert.True(t, filter.Apply(metadata.RequestMetadata{}, upstreamConfig))
 }
 
 func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -33,6 +33,7 @@ func TestAndFilter_Apply(t *testing.T) {
 	}
 
 	args := argsType{upstreamConfig: cfg("test-node")}
+
 	tests := []struct { //nolint:govet // field alignment doesn't matter in tests
 		name   string
 		fields fields
@@ -81,15 +82,21 @@ func TestIsCloseToGlobalMaxHeight_Apply(t *testing.T) {
 	blockHeightCheck.EXPECT().GetError().Return(nil)
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(85).Once()
+
 	ok := filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
+
 	assert.False(t, ok)
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(91).Once()
+
 	ok = filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
+
 	assert.True(t, ok)
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(99).Once()
+
 	ok = filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
+
 	assert.True(t, ok)
 }
 

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -12,14 +12,14 @@ import (
 
 type AlwaysPass struct{}
 
-func (AlwaysPass) Apply(metadata.RequestMetadata, *config.UpstreamConfig) bool {
-	return true
+func (AlwaysPass) Apply(metadata.RequestMetadata, *config.UpstreamConfig) (bool, error) {
+	return true, nil
 }
 
 type AlwaysFail struct{}
 
-func (AlwaysFail) Apply(metadata.RequestMetadata, *config.UpstreamConfig) bool {
-	return false
+func (AlwaysFail) Apply(metadata.RequestMetadata, *config.UpstreamConfig) (bool, error) {
+	return false, nil
 }
 
 func TestAndFilter_Apply(t *testing.T) {
@@ -27,29 +27,31 @@ func TestAndFilter_Apply(t *testing.T) {
 		filters []NodeFilter
 	}
 
-	type args struct { //nolint:govet // field alignment doesn't matter in tests
+	type argsType struct { //nolint:govet // field alignment doesn't matter in tests
 		requestMetadata metadata.RequestMetadata
 		upstreamConfig  *config.UpstreamConfig
 	}
 
+	args := argsType{upstreamConfig: cfg("test-node")}
 	tests := []struct { //nolint:govet // field alignment doesn't matter in tests
 		name   string
 		fields fields
-		args   args
+		args   argsType
 		want   bool
 	}{
-		{"No filters", fields{}, args{}, true},
-		{"One passing filter", fields{[]NodeFilter{AlwaysPass{}}}, args{}, true},
-		{"Multiple passing filters", fields{[]NodeFilter{AlwaysPass{}, AlwaysPass{}, AlwaysPass{}}}, args{}, true},
-		{"One failing filter", fields{[]NodeFilter{AlwaysFail{}}}, args{}, false},
-		{"Multiple passing and one failing", fields{[]NodeFilter{AlwaysPass{}, AlwaysPass{}, AlwaysFail{}}}, args{}, false},
+		{"No filters", fields{}, args, true},
+		{"One passing filter", fields{[]NodeFilter{AlwaysPass{}}}, args, true},
+		{"Multiple passing filters", fields{[]NodeFilter{AlwaysPass{}, AlwaysPass{}, AlwaysPass{}}}, args, true},
+		{"One failing filter", fields{[]NodeFilter{AlwaysFail{}}}, args, false},
+		{"Multiple passing and one failing", fields{[]NodeFilter{AlwaysPass{}, AlwaysPass{}, AlwaysFail{}}}, args, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := &AndFilter{
 				filters: tt.fields.filters,
 			}
-			assert.Equalf(t, tt.want, a.Apply(tt.args.requestMetadata, tt.args.upstreamConfig), "Apply(%v, %v)", tt.args.requestMetadata, tt.args.upstreamConfig)
+			ok, _ := a.Apply(tt.args.requestMetadata, tt.args.upstreamConfig)
+			assert.Equalf(t, tt.want, ok, "Apply(%v, %v)", tt.args.requestMetadata, tt.args.upstreamConfig)
 		})
 	}
 }
@@ -79,13 +81,16 @@ func TestIsCloseToGlobalMaxHeight_Apply(t *testing.T) {
 	blockHeightCheck.EXPECT().GetError().Return(nil)
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(85).Once()
-	assert.False(t, filter.Apply(metadata.RequestMetadata{}, upstreamConfig))
+	ok, _ := filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
+	assert.False(t, ok)
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(91).Once()
-	assert.True(t, filter.Apply(metadata.RequestMetadata{}, upstreamConfig))
+	ok, _ = filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
+	assert.True(t, ok)
 
 	blockHeightCheck.EXPECT().GetBlockHeight().Return(99).Once()
-	assert.True(t, filter.Apply(metadata.RequestMetadata{}, upstreamConfig))
+	ok, _ = filter.Apply(metadata.RequestMetadata{}, upstreamConfig)
+	assert.True(t, ok)
 }
 
 func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {
@@ -114,7 +119,8 @@ func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &SimpleIsStatePresent{}
-			assert.Equalf(t, tt.want, f.Apply(tt.args.requestMetadata, tt.args.upstreamConfig), "Apply(%v, %v)", tt.args.requestMetadata, tt.args.upstreamConfig)
+			ok, _ := f.Apply(tt.args.requestMetadata, tt.args.upstreamConfig)
+			assert.Equalf(t, tt.want, ok, "Apply(%v, %v)", tt.args.requestMetadata, tt.args.upstreamConfig)
 		})
 	}
 }


### PR DESCRIPTION
# Description

High-level notes:
1. **The filters are pretty verbose now.** This is because each boolean that would cause the filter to fail is checked separately, so that it can be reported accurately in the logs. The verbosity is fairly annoying, but it makes it very easy to check and verify the routing logic simply by looking at the logs. We can revert back to a more succinct version when we're more used to working with these and we're okay with dropping the logging.
2. **The `IsHealthy` filter is broken down into separate Peers and Syncing filters.** When implemented in a single function, it was unnecessarily complicated to properly handle all the failure cases and add logging accordingly. Breaking it down makes each filter fairly simple on its own, and it's also easy to combine them because we can reuse the `AndFilter` 🙂 
3. **The NodeFilters access some `*Check` internals.** For example, the `HasEnoughPeers` filter needs to access the `err` field of the `PeerCheck` object. This seems tolerable for now, but I'm totally open to changing it. 
4. **The `IsPassing` methods of the various `Checker`s are gradually becoming redundant.** As I move the corresponding logic to `NodeFilter`s, I don't think any production code uses the `IsPassing` methods anymore. I didn't remove them here because it would've required moving some more code around to get the tests to work and I didn't want to make the PR too huge.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Deployed to staging and made sure I see the logging messages I expect for various <request, upstream> combinations.