### PR TITLE
feat: support batch requests

### DIFF
--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -184,7 +184,7 @@ func decode[T Decodable](rawBytes []byte) (*T, error) {
 	return &body, nil
 }
 
-func CreateErrorJSONRPCResponseBody(message string, jsonRPCStatusCode int) ResponseBody {
+func CreateErrorJSONRPCResponseBody(message string, jsonRPCStatusCode int) *SingleResponseBody {
 	return &SingleResponseBody{
 		JSONRPC: JSONRPCVersion,
 		Error: &Error{
@@ -197,14 +197,10 @@ func CreateErrorJSONRPCResponseBody(message string, jsonRPCStatusCode int) Respo
 func CreateErrorJSONRPCResponseBodyWithRequest(message string, jsonRPCStatusCode int, request RequestBody) ResponseBody {
 	switch r := request.(type) {
 	case *SingleRequestBody:
-		return &SingleResponseBody{
-			JSONRPC: r.JSONRPCVersion,
-			Error: &Error{
-				Code:    jsonRPCStatusCode,
-				Message: message,
-			},
-			ID: int(r.ID),
-		}
+		response := CreateErrorJSONRPCResponseBody(message, jsonRPCStatusCode)
+		response.ID = int(r.ID)
+
+		return response
 	case *BatchRequestBody:
 		subRequests := r.GetSubRequests()
 		responses := make([]SingleResponseBody, 0, len(subRequests))
@@ -225,12 +221,7 @@ func CreateErrorJSONRPCResponseBodyWithRequest(message string, jsonRPCStatusCode
 			Responses: responses,
 		}
 	default:
-		return &SingleResponseBody{
-			JSONRPC: JSONRPCVersion,
-			Error: &Error{
-				Code:    jsonRPCStatusCode,
-				Message: message,
-			},
-		}
+		response := CreateErrorJSONRPCResponseBody(message, jsonRPCStatusCode)
+		return response
 	}
 }

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -1,0 +1,158 @@
+package jsonrpc
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeAndDecodeRequests(t *testing.T) {
+	for _, tc := range []struct {
+		expectedRequest RequestBody
+		testName        string
+		body            string
+	}{
+		{
+			testName: "single request",
+			body:     "{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"],\"id\":67}",
+			expectedRequest: &SingleRequestBody{
+				JSONRPCVersion: "2.0",
+				Method:         "web3_clientVersion",
+				Params:         []any{"hi"},
+				ID:             67,
+			},
+		},
+		{
+			testName: "single request in batch",
+			body:     "[{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"],\"id\":67}]",
+			expectedRequest: &BatchRequestBody{
+				Requests: []SingleRequestBody{
+					{
+						JSONRPCVersion: "2.0",
+						Method:         "web3_clientVersion",
+						Params:         []any{"hi"},
+						ID:             67,
+					},
+				},
+			},
+		},
+		{
+			testName: "batch requests",
+			body: "[" +
+				"{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"],\"id\":67}," +
+				"{\"jsonrpc\":\"2.0\",\"method\":\"web3_weee\",\"params\":[\"hi\"],\"id\":68}," +
+				"{\"jsonrpc\":\"2.0\",\"method\":\"web3_something_else\",\"params\":[\"hello\"],\"id\":69}" +
+				"]",
+			expectedRequest: &BatchRequestBody{
+				Requests: []SingleRequestBody{
+					{
+						JSONRPCVersion: "2.0",
+						Method:         "web3_clientVersion",
+						Params:         []any{"hi"},
+						ID:             67,
+					},
+					{
+						JSONRPCVersion: "2.0",
+						Method:         "web3_weee",
+						Params:         []any{"hi"},
+						ID:             68,
+					},
+					{
+						JSONRPCVersion: "2.0",
+						Method:         "web3_something_else",
+						Params:         []any{"hello"},
+						ID:             69,
+					},
+				},
+			},
+		},
+	} {
+		req := http.Request{
+			Body: io.NopCloser(bytes.NewReader([]byte(tc.body))),
+		}
+		decoded, err := DecodeRequestBody(&req)
+
+		assert.Nil(t, err)
+		assert.Equal(t, tc.expectedRequest, decoded)
+
+		encoded, err := decoded.Encode()
+
+		assert.Nil(t, err)
+		assert.Equal(t, tc.body, string(encoded))
+	}
+}
+
+func TestEncodeAndDecodeResponses(t *testing.T) {
+	for _, tc := range []struct {
+		expectedResponse ResponseBody
+		testName         string
+		body             string
+	}{
+		{
+			testName: "single response",
+			body:     "{\"result\":\"haha\",\"jsonrpc\":\"2.0\",\"id\":67}",
+			expectedResponse: &SingleResponseBody{
+				Result:  "haha",
+				JSONRPC: "2.0",
+				ID:      67,
+			},
+		},
+		{
+			testName: "single response in batch",
+			body:     "[{\"result\":\"haha\",\"jsonrpc\":\"2.0\",\"id\":67}]",
+			expectedResponse: &BatchResponseBody{
+				Responses: []SingleResponseBody{
+					{
+						Result:  "haha",
+						JSONRPC: "2.0",
+						ID:      67,
+					},
+				},
+			},
+		},
+		{
+			testName: "batch responses",
+			body: "[" +
+				"{\"result\":\"haha\",\"jsonrpc\":\"2.0\",\"id\":67}," +
+				"{\"result\":\"something\",\"jsonrpc\":\"2.0\",\"id\":68}," +
+				"{\"result\":\"else\",\"jsonrpc\":\"2.0\",\"id\":69}" +
+				"]",
+			expectedResponse: &BatchResponseBody{
+				Responses: []SingleResponseBody{
+					{
+						Result:  "haha",
+						JSONRPC: "2.0",
+						ID:      67,
+					},
+					{
+						Result:  "something",
+						JSONRPC: "2.0",
+						ID:      68,
+					},
+					{
+						Result:  "else",
+						JSONRPC: "2.0",
+						ID:      69,
+					},
+				},
+			},
+		},
+	} {
+		resp := http.Response{
+			Body: io.NopCloser(bytes.NewReader([]byte(tc.body))),
+		}
+
+		decoded, err := DecodeResponseBody(&resp)
+
+		assert.Nil(t, err)
+		assert.Equal(t, tc.expectedResponse, decoded)
+
+		encoded, err := decoded.Encode()
+
+		assert.Nil(t, err)
+		assert.Equal(t, tc.body, string(encoded))
+	}
+}

--- a/internal/metadata/request_metadata_parser.go
+++ b/internal/metadata/request_metadata_parser.go
@@ -58,5 +58,4 @@ func isTraceMethod(method string) bool {
 	default:
 		return false
 	}
-
 }

--- a/internal/metadata/request_metadata_parser.go
+++ b/internal/metadata/request_metadata_parser.go
@@ -7,19 +7,56 @@ import (
 type RequestMetadataParser struct{}
 
 func (p *RequestMetadataParser) Parse(requestBody jsonrpc.RequestBody) RequestMetadata {
-	result := RequestMetadata{}
+	switch requestBody.(type) {
+	case *jsonrpc.SingleRequestBody:
+		return RequestMetadata{
+			IsStateRequired: isStateRequiredForMethod(requestBody.GetMethod()),
+			IsTraceMethod:   isTraceMethod(requestBody.GetMethod()),
+		}
+	case *jsonrpc.BatchRequestBody:
+		result := RequestMetadata{
+			IsStateRequired: false,
+			IsTraceMethod:   false,
+		}
 
-	switch requestBody.Method {
+		for _, requestBody := range requestBody.GetSubRequests() {
+			if isStateRequiredForMethod(requestBody.Method) {
+				result.IsStateRequired = true
+			}
+
+			if isTraceMethod(requestBody.Method) {
+				result.IsTraceMethod = true
+			}
+
+			if result.IsStateRequired && result.IsTraceMethod {
+				break
+			}
+		}
+
+		return result
+	default:
+		panic("Invalid request body type   ")
+	}
+}
+
+func isStateRequiredForMethod(method string) bool {
+	switch method {
 	case "eth_getBalance", "eth_getStorageAt", "eth_getTransactionCount", "eth_getCode", "eth_call", "eth_estimateGas":
 		// List of state methods: https://ethereum.org/en/developers/docs/apis/json-rpc/#state_methods
-		result.IsStateRequired = true
+		return true
+	default:
+		return false
+	}
+}
+
+func isTraceMethod(method string) bool {
+	switch method {
 	case "trace_filter", "trace_block", "trace_get", "trace_transaction", "trace_call", "trace_callMany",
 		"trace_rawTransaction", "trace_replayBlockTransactions", "trace_replayTransaction":
 		// List of trace methods: https://openethereum.github.io/JSONRPC-trace-module
-		result.IsTraceMethod = true
+		return true
 	default:
-		result.IsStateRequired = false
+		return false
 	}
 
-	return result
 }

--- a/internal/metadata/request_metadata_parser_test.go
+++ b/internal/metadata/request_metadata_parser_test.go
@@ -19,7 +19,6 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 	}
 
 	testForSingleRequest := func(methodName string, isStateRequired, isTraceMethod bool) testArgs {
-
 		return testArgs{
 			args{
 				requestBody: &jsonrpc.SingleRequestBody{

--- a/internal/metadata/request_metadata_parser_test.go
+++ b/internal/metadata/request_metadata_parser_test.go
@@ -13,15 +13,42 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 	}
 
 	type testArgs struct {
-		name string
 		args args
+		name string
 		want RequestMetadata
 	}
 
-	testForMethod := func(methodName string, isStateRequired, isTraceMethod bool) testArgs {
+	testForSingleRequest := func(methodName string, isStateRequired, isTraceMethod bool) testArgs {
+
 		return testArgs{
+			args{
+				requestBody: &jsonrpc.SingleRequestBody{
+					Method: methodName,
+				},
+			},
 			methodName,
-			args{jsonrpc.RequestBody{Method: methodName}},
+			RequestMetadata{
+				IsStateRequired: isStateRequired,
+				IsTraceMethod:   isTraceMethod,
+			},
+		}
+	}
+
+	testForBatchRequest := func(testName string, methodNames []string, isStateRequired bool, isTraceMethod bool) testArgs {
+		requests := make([]jsonrpc.SingleRequestBody, 0)
+		for _, methodName := range methodNames {
+			requests = append(requests, jsonrpc.SingleRequestBody{
+				Method: methodName,
+			})
+		}
+
+		return testArgs{
+			args{
+				requestBody: &jsonrpc.BatchRequestBody{
+					Requests: requests,
+				},
+			},
+			testName,
 			RequestMetadata{
 				IsStateRequired: isStateRequired,
 				IsTraceMethod:   isTraceMethod,
@@ -30,11 +57,19 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 	}
 
 	tests := []testArgs{
-		testForMethod("eth_call", true, false),
-		testForMethod("eth_getBalance", true, false),
-		testForMethod("eth_getBlockByNumber", false, false),
-		testForMethod("eth_getTransactionReceipt", false, false),
-		testForMethod("trace_filter", false, true),
+		testForSingleRequest("eth_call", true, false),
+		testForSingleRequest("eth_getBalance", true, false),
+		testForSingleRequest("eth_getBlockByNumber", false, false),
+		testForSingleRequest("eth_getTransactionReceipt", false, false),
+		testForSingleRequest("trace_filter", false, true),
+		testForSingleRequest("trace_replayBlockTransactions", false, true),
+		testForBatchRequest("batch eth_call", []string{"eth_call"}, true, false),
+		testForBatchRequest("batch eth_call w/ eth_getTransactionReceipt",
+			[]string{"eth_call", "eth_getTransactionReceipt"}, true, false),
+		testForBatchRequest("batch trace w/ eth_getTransactionReceipt",
+			[]string{"trace_filter", "eth_getTransactionReceipt"}, false, true),
+		testForBatchRequest("batch eth_call w/ eth_getTransactionReceipt and trace",
+			[]string{"eth_call", "eth_getTransactionReceipt", "trace_filter"}, true, true),
 	}
 
 	for _, tt := range tests {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -70,6 +70,18 @@ var (
 			Name:      "upstream_rpc_requests",
 			Help:      "Count of total RPC requests forwarded to upstreams.",
 		},
+		// jsonrpc_method is "batch" for batch requests
+		[]string{"client", "upstream_id", "url", "jsonrpc_method"},
+	)
+
+	UpstreamJSONRPCRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "router",
+			Name:      "upstream_jsonrpc_requests",
+			Help: "Count of total JSON RPC requests forwarded to upstreamsm including ones in batches. " +
+				"Batches are deconstructed to single JSON RPC requests for this metric.",
+		},
 		[]string{"client", "upstream_id", "url", "jsonrpc_method"},
 	)
 
@@ -80,6 +92,19 @@ var (
 			Name:      "upstream_rpc_request_errors",
 			Help:      "Count of total errors when forwarding RPC requests to upstreams.",
 		},
+		// jsonrpc_method is "batch" for batch requests
+		[]string{"client", "upstream_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
+	)
+
+	UpstreamJSONRPCRequestErrorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: "router",
+			Name:      "upstream_jsonrpc_request_errors",
+			Help: "Count of total errors when forwarding RPC requests to upstreams, including ones in batches. " +
+				"Batches are deconstructed to single JSON RPC requests for this metric.",
+		},
+		// jsonrpc_method is "batch" for batch requests
 		[]string{"client", "upstream_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
 	)
 
@@ -91,6 +116,7 @@ var (
 			Help:      "Latency of RPC requests forwarded to upstreams.",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
 		},
+		// jsonrpc_method is "batch" for batch requests
 		[]string{"client", "upstream_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
 	)
 

--- a/internal/mocks/HealthCheckManager.go
+++ b/internal/mocks/HealthCheckManager.go
@@ -42,7 +42,7 @@ type HealthCheckManager_GetUpstreamStatus_Call struct {
 }
 
 // GetUpstreamStatus is a helper method to define mock.On call
-//   - upstreamID string
+//  - upstreamID string
 func (_e *HealthCheckManager_Expecter) GetUpstreamStatus(upstreamID interface{}) *HealthCheckManager_GetUpstreamStatus_Call {
 	return &HealthCheckManager_GetUpstreamStatus_Call{Call: _e.mock.On("GetUpstreamStatus", upstreamID)}
 }

--- a/internal/mocks/Router.go
+++ b/internal/mocks/Router.go
@@ -30,15 +30,15 @@ func (_m *Router) IsInitialized() bool {
 }
 
 // Route provides a mock function with given fields: ctx, requestBody
-func (_m *Router) Route(ctx context.Context, requestBody jsonrpc.RequestBody) (*jsonrpc.ResponseBody, *http.Response, error) {
+func (_m *Router) Route(ctx context.Context, requestBody jsonrpc.RequestBody) (jsonrpc.ResponseBody, *http.Response, error) {
 	ret := _m.Called(ctx, requestBody)
 
-	var r0 *jsonrpc.ResponseBody
-	if rf, ok := ret.Get(0).(func(context.Context, jsonrpc.RequestBody) *jsonrpc.ResponseBody); ok {
+	var r0 jsonrpc.ResponseBody
+	if rf, ok := ret.Get(0).(func(context.Context, jsonrpc.RequestBody) jsonrpc.ResponseBody); ok {
 		r0 = rf(ctx, requestBody)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*jsonrpc.ResponseBody)
+			r0 = ret.Get(0).(jsonrpc.ResponseBody)
 		}
 	}
 

--- a/internal/mocks/RoutingStrategy.go
+++ b/internal/mocks/RoutingStrategy.go
@@ -49,8 +49,8 @@ type MockRoutingStrategy_RouteNextRequest_Call struct {
 }
 
 // RouteNextRequest is a helper method to define mock.On call
-//   - upstreamsByPriority types.PriorityToUpstreamsMap
-//   - requestMetadata metadata.RequestMetadata
+//  - upstreamsByPriority types.PriorityToUpstreamsMap
+//  - requestMetadata metadata.RequestMetadata
 func (_e *MockRoutingStrategy_Expecter) RouteNextRequest(upstreamsByPriority interface{}, requestMetadata interface{}) *MockRoutingStrategy_RouteNextRequest_Call {
 	return &MockRoutingStrategy_RouteNextRequest_Call{Call: _e.mock.On("RouteNextRequest", upstreamsByPriority, requestMetadata)}
 }

--- a/internal/route/request_executor.go
+++ b/internal/route/request_executor.go
@@ -18,12 +18,18 @@ type RequestExecutor struct {
 	httpClient client.HTTPClient
 }
 
+type ExecutorResult struct {
+	err               error
+	httpResponse      *http.Response
+	batchResponseBody jsonrpc.BatchResponseBody
+}
+
 func (r *RequestExecutor) routeToConfig(
 	ctx context.Context,
 	requestBody jsonrpc.RequestBody,
 	configToRoute *config.UpstreamConfig,
-) (*jsonrpc.ResponseBody, *http.Response, error) {
-	bodyBytes, err := requestBody.EncodeRequestBody()
+) (jsonrpc.ResponseBody, *http.Response, error) {
+	bodyBytes, err := requestBody.Encode()
 	if err != nil {
 		zap.L().Error("Could not serialize request.", zap.Any("request", requestBody), zap.Error(err))
 		return nil, nil, err

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -37,7 +37,7 @@ func TestRouter_NoHealthyUpstreams(t *testing.T) {
 	router.(*SimpleRouter).healthCheckManager = managerMock
 	router.Start()
 
-	jsonResp, httpResp, err := router.Route(context.Background(), jsonrpc.RequestBody{})
+	jsonResp, httpResp, err := router.Route(context.Background(), &jsonrpc.BatchRequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, jsonResp)
@@ -110,12 +110,12 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	jsonRcpResp, httpResp, err := router.Route(context.Background(), jsonrpc.RequestBody{})
+	jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)
 	assert.Equal(t, 203, httpResp.StatusCode)
-	assert.NotNil(t, "hello", jsonRcpResp.Result)
+	assert.Equal(t, "hello", jsonRPCResp.(*jsonrpc.SingleResponseBody).Result)
 	routingStrategyMock.AssertCalled(t, "RouteNextRequest", types.PriorityToUpstreamsMap{
 		0: {&gethConfig},
 		1: {&erigonConfig},
@@ -155,12 +155,12 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	jsonRcpResp, httpResp, err := router.Route(context.Background(), jsonrpc.RequestBody{})
+	jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)
 	assert.Equal(t, 203, httpResp.StatusCode)
-	assert.NotNil(t, "hello", jsonRcpResp.Result)
+	assert.Equal(t, "hello", jsonRPCResp.(*jsonrpc.SingleResponseBody).Result)
 	routingStrategyMock.AssertCalled(t, "RouteNextRequest", types.PriorityToUpstreamsMap{
 		0: {&gethConfig, &erigonConfig},
 	}, metadata.RequestMetadata{IsStateRequired: false})

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -123,19 +123,19 @@ func (h *RPCHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	body, err := jsonrpc.DecodeRequestBody(req)
+	requestBody, err := jsonrpc.DecodeRequestBody(req)
 	if err != nil {
 		errMsg := fmt.Sprintf("Request body could not be parsed, err: %s", err.Error())
-		resp := jsonrpc.CreateErrorJSONRPCResponseBody(errMsg, jsonrpc.InternalServerErrorCode, int(body.ID))
+		resp := jsonrpc.CreateErrorJSONRPCResponseBody(errMsg, jsonrpc.InternalServerErrorCode)
 		zap.L().Error(errMsg)
-		respondJSONRPC(writer, &resp, http.StatusBadRequest)
+		respondJSONRPC(writer, resp, http.StatusBadRequest)
 
 		return
 	}
 
-	zap.L().Debug("Request received.", zap.String("method", req.Method), zap.String("path", req.URL.Path), zap.String("query", req.URL.RawQuery), zap.Any("body", body))
+	zap.L().Debug("Request received.", zap.String("method", req.Method), zap.String("path", req.URL.Path), zap.String("query", req.URL.RawQuery), zap.Any("body", requestBody))
 
-	respBody, resp, err := h.router.Route(ctx, *body)
+	respBody, resp, err := h.router.Route(ctx, requestBody)
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -146,8 +146,8 @@ func (h *RPCHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 			respondRaw(writer, e.Content, http.StatusOK)
 			return
 		default:
-			resp := jsonrpc.CreateErrorJSONRPCResponseBody(fmt.Sprintf("Request could not be routed, err: %s", err.Error()), jsonrpc.InternalServerErrorCode, int(body.ID))
-			respondJSONRPC(writer, &resp, http.StatusInternalServerError)
+			resp := jsonrpc.CreateErrorJSONRPCResponseBodyWithRequest(fmt.Sprintf("Request could not be routed, err: %s", err.Error()), jsonrpc.InternalServerErrorCode, requestBody)
+			respondJSONRPC(writer, resp, http.StatusInternalServerError)
 
 			return
 		}
@@ -155,7 +155,7 @@ func (h *RPCHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 
 	respondJSONRPC(writer, respBody, resp.StatusCode)
 
-	zap.L().Debug("Request successfully routed.", zap.Any("requestBody", body))
+	zap.L().Debug("Request successfully routed.", zap.Any("requestBody", requestBody))
 }
 
 func getClientID(req *http.Request) string {
@@ -171,13 +171,13 @@ func getClientID(req *http.Request) string {
 	return "unknown"
 }
 
-func respondJSONRPC(writer http.ResponseWriter, response *jsonrpc.ResponseBody, httpStatusCode int) {
+func respondJSONRPC(writer http.ResponseWriter, response jsonrpc.ResponseBody, httpStatusCode int) {
 	if response == nil {
 		writer.WriteHeader(httpStatusCode)
 		return
 	}
 
-	respBytes, err := response.EncodeResponseBody()
+	respBytes, err := response.Encode()
 	if err != nil {
 		zap.L().Error("Failed to serialize response.", zap.Error(err), zap.String("response", string(respBytes)))
 		return

--- a/internal/server/web_server_test.go
+++ b/internal/server/web_server_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestHandleJSONRPCRequest_Success(t *testing.T) {
 	router := mocks.NewRouter(t)
-	expectedRPCResponse := &jsonrpc.ResponseBody{
+	expectedRPCResponse := &jsonrpc.SingleResponseBody{
 		JSONRPC: jsonrpc.JSONRPCVersion,
 		Result:  "results",
 		ID:      2,


### PR DESCRIPTION
# Description

### Some background
* Why support batching?
   *  Moving to relying on free node providers. Many of these impose stringent rate limiting, which we can hopefully get around by batching requests.
   * Performance. Some preliminary tests suggest that batching will speed up initial indexing. Further investigation is needed here.

* We discussed the idea of splitting of batches. 
   * For example if one part of the batch is stateful requests and another part is non-stateful, should we split the batch up, send them to their respective upstreams, and then merge the results? 
   * Should we split up large batches and route them to upstreams in parallel in order to decrease latency?
* We landed on not splitting up batches due to tricky handling of partial failures and also the possibility of data inconsistencies of getting routed to different upstreams
* For state/non-state splitting, we decided that if a batch contains >= 1 state method, then route the entire batch to an archive node. We shouldn't run into this case currently as the Graph Indexers are only batching `get_transaction_receipt` calls.


### Lifecycle of request
* Receiving request: Convert all requests into `BatchRequestBody`, even for non-batch requests. Handling a single struct type is easier.
   *  The `IsOriginallyBatch` is needed to distinguish requests that are non-batch from batch requests with a size of 1.
* Routing to upstream: deserialize `BatchRequestBody` into its original form - either batch or non batch.
   *  If **_any_** request in the batch is a state method, route it to archive nodes.
* Receiving response from upstream: deserialize into `BatchResponseBody`, even for non-batch requests. 
* When sending response back to client: serialize `BatchResponseBody` into its original form - either batch or non-batch.

### Metrics
I don't think it's perfect, but haven't thought of a clear & good way to incorporate the concept of batches. 

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Unit tests pass

Manual testing:
```
➜  node-gateway git:(batch_req) ✗ curl --location --request POST 'localhost:8080' \
--header 'Content-Type: application/json' \
--data-raw '{
        "jsonrpc":"2.0",
        "method":"eth_blockNumber",
        "params":[],
        "id":1
}'
```

```
{"result":"0xef84f1","jsonrpc":"2.0","id":1}%                            
➜  node-gateway git:(batch_req) ✗ curl --location --request POST 'localhost:8080' \
--header 'Content-Type: application/json' \
--data-raw '[{
        "jsonrpc":"2.0",
        "method":"eth_blockNumber",
        "params":[],
        "id":1
}]'
[{"result":"0xef84f2","jsonrpc":"2.0","id":1}]%     
```

```
➜  node-gateway git:(batch_req) ✗ curl --location --request POST 'localhost:8080' \
--header 'Content-Type: application/json' \
--data-raw '[{
        "jsonrpc":"2.0",
        "method":"eth_blockNumber",
        "params":[],
        "id":1
},{
        "jsonrpc":"2.0",
        "method":"eth_blockNumber",
        "params":[],
        "id":1
},{
        "jsonrpc":"2.0",
        "method":"eth_blockNumber",
        "params":[],
        "id":1
}]'
[{"result":"0xef84f3","jsonrpc":"2.0","id":1},{"result":"0xef84f3","jsonrpc":"2.0","id":1},{"result":"0xef84f3","jsonrpc":"2.0","id":1}]% 
```

Manually validated with debug logs that batches w/ state methods are getting routed to archive nodes.
```
➜  node-gateway git:(batch_req) ✗ >....                                  
        "jsonrpc":"2.0",
        "method":"eth_blockNumber",
        "params":[],
        "id":1
},{
        "jsonrpc":"2.0",
        "method":"eth_blockNumber",
        "params":[],
        "id":1
},
{
        "jsonrpc":"2.0",
        "method":"eth_call",
        "params":[{
                "to": "0xcaa7349cea390f89641fe306d93591f87595dc1f",
                "data": "0xeb3537cc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000061174e65"
        }, "0x1EFE3CA"],
        "id":100006
}
]'
[{"result":"0xef84fa","jsonrpc":"2.0","id":1},{"result":"0xef84fa","jsonrpc":"2.0","id":1},{"result":"0xef84fa","jsonrpc":"2.0","id":1},{"result":"0x","jsonrpc":"2.0","id":100006}]%                   
```

# Actual indexer test
Deployed a subgraph to staging and it's making progress
![image](https://user-images.githubusercontent.com/6441090/195650737-b82720b7-40ec-467a-ad2a-023509041561.png)


I'm seeing more 503s (no healthy upstreams) after deploying new version:
![image](https://user-images.githubusercontent.com/6441090/195652133-328522ee-b3c1-4044-a2e7-fa54ec77a996.png)
```
2022-10-13T09:39:27.090Z	DEBUG	route/routing_strategy.go:51	Did not find any healthy nodes in priority.	{"priority": 1}
2022-10-13T09:39:27.097Z	DEBUG	route/routing_strategy.go:51	Did not find any healthy nodes in priority.	{"priority": 1}
```
This is expected behavior. The config on the staging gateway is:
```
[ec2-user@ip-172-31-25-181 ~]$ cat gateway_config.yml
global:
  port: 8080

routing:
  maxBlocksBehind: 10

groups:
  - id: primary
    priority: 0
  - id: fallback
    priority: 1

upstreams:
  - id: geth-full
    httpURL: "http://172.31.19.35:8545"
    group: primary
    nodeType: full
  - id: erigon-eth-archive-prod-1
    httpURL: "http://172.31.40.161:8545"
    group: fallback
    nodeType: archive
  - id: erigon-eth-archive-prod-2
    httpURL: "http://172.31.47.202:8545"
    group: fallback
    nodeType: full
```

sometimes state methods fail because the only archive is behind the group's highest block.
