### PR TITLE
refactor: add metrics.Container to prepare for per-chain metrics

### DIFF
--- a/internal/checks/blockheight.go
+++ b/internal/checks/blockheight.go
@@ -76,7 +76,7 @@ func (c *BlockHeightCheck) initializeWebsockets() error {
 func (c *BlockHeightCheck) initializeHTTP() {
 	httpClient, err := c.clientGetter(c.upstreamConfig.HTTPURL, &client.BasicAuthCredentials{Username: c.upstreamConfig.BasicAuthConfig.Username, Password: c.upstreamConfig.BasicAuthConfig.Password})
 	if err != nil {
-		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPInit).Inc()
+		c.metricsContainer.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPInit).Inc()
 		c.blockHeightError = err
 
 		return
@@ -105,7 +105,7 @@ func (c *BlockHeightCheck) runCheckHTTP() {
 	runCheck := func() {
 		header, err := c.httpClient.HeaderByNumber(context.Background(), nil)
 		if c.blockHeightError = err; c.blockHeightError != nil {
-			metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPRequest).Inc()
+			c.metricsContainer.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPRequest).Inc()
 			return
 		}
 
@@ -117,8 +117,8 @@ func (c *BlockHeightCheck) runCheckHTTP() {
 	}
 
 	runCheckWithMetrics(runCheck,
-		metrics.BlockHeightCheckRequests.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL),
-		metrics.BlockHeightCheckDuration.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL))
+		c.metricsContainer.BlockHeightCheckRequests.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL),
+		c.metricsContainer.BlockHeightCheckDuration.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL))
 }
 
 func (c *BlockHeightCheck) IsPassing(maxBlockHeight uint64) bool {
@@ -158,7 +158,7 @@ func (c *BlockHeightCheck) subscribeNewHead() error {
 	onError := func(failure string) {
 		zap.L().Error("Encountered error in NewHead Websockets subscription.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.String("WSURL", c.upstreamConfig.WSURL))
 
-		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.WSError).Inc()
+		c.metricsContainer.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.WSError).Inc()
 		c.webSocketError = errors.New(failure)
 		c.blockHeightError = c.webSocketError
 	}
@@ -170,7 +170,7 @@ func (c *BlockHeightCheck) subscribeNewHead() error {
 	}
 
 	if err = subscribeNewHeads(wsClient, &newHeadHandler{onNewHead: onNewHead, onError: onError}); err != nil {
-		metrics.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.WSSubscribe).Inc()
+		c.metricsContainer.BlockHeightCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.WSSubscribe).Inc()
 		c.webSocketError = err
 
 		return err

--- a/internal/checks/blockheight_test.go
+++ b/internal/checks/blockheight_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/satsuma-data/node-gateway/internal/metadata"
+	"github.com/satsuma-data/node-gateway/internal/metrics"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/satsuma-data/node-gateway/internal/client"
@@ -36,7 +37,7 @@ func TestBlockHeightChecker_WS(t *testing.T) {
 	chainMetadataStore := metadata.NewChainMetadataStore()
 	chainMetadataStore.Start()
 
-	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore)
+	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer())
 
 	ethClient.AssertNumberOfCalls(t, "SubscribeNewHead", 1)
 
@@ -64,7 +65,7 @@ func TestBlockHeightChecker_WSSubscribeFailed(t *testing.T) {
 	chainMetadataStore := metadata.NewChainMetadataStore()
 	chainMetadataStore.Start()
 
-	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore)
+	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer())
 
 	ethClient.AssertNumberOfCalls(t, "SubscribeNewHead", 1)
 	assert.False(t, checker.IsPassing(maxBlockHeight))
@@ -99,7 +100,7 @@ func TestBlockHeightChecker_HTTP(t *testing.T) {
 		chainMetadataStore := metadata.NewChainMetadataStore()
 		chainMetadataStore.Start()
 
-		checker := NewBlockHeightChecker(config, mockEthClientGetter, chainMetadataStore)
+		checker := NewBlockHeightChecker(config, mockEthClientGetter, chainMetadataStore, metrics.NewContainer())
 
 		checker.RunCheck()
 		ethClient.AssertNumberOfCalls(t, "SubscribeNewHead", 0)

--- a/internal/checks/manager.go
+++ b/internal/checks/manager.go
@@ -38,7 +38,7 @@ type healthCheckManager struct {
 	ethClientGetter     client.EthClientGetter
 	newBlockHeightCheck func(*conf.UpstreamConfig, client.EthClientGetter, BlockHeightObserver, *metrics.Container) types.BlockHeightChecker
 	newPeerCheck        func(*conf.UpstreamConfig, client.EthClientGetter, *metrics.Container) types.Checker
-	newSyncingCheck     func(*conf.UpstreamConfig, client.EthClientGetter) types.Checker
+	newSyncingCheck     func(*conf.UpstreamConfig, client.EthClientGetter, *metrics.Container) types.Checker
 	blockHeightObserver BlockHeightObserver
 	healthCheckTicker   *time.Ticker
 	metricsContainer    *metrics.Container
@@ -127,7 +127,7 @@ func (h *healthCheckManager) initializeChecks() {
 			go func() {
 				defer innerWG.Done()
 
-				syncingCheck = h.newSyncingCheck(&config, client.NewEthClient)
+				syncingCheck = h.newSyncingCheck(&config, client.NewEthClient, h.metricsContainer)
 			}()
 
 			innerWG.Wait()

--- a/internal/checks/manager_test.go
+++ b/internal/checks/manager_test.go
@@ -60,6 +60,7 @@ func TestHealthCheckManager(t *testing.T) {
 	manager.(*healthCheckManager).newSyncingCheck = func(
 		upstreamConfig *config.UpstreamConfig,
 		clientGetter client.EthClientGetter,
+		metricsContainer *metrics.Container,
 	) types.Checker {
 		return mockSyncingChecker
 	}

--- a/internal/checks/manager_test.go
+++ b/internal/checks/manager_test.go
@@ -53,6 +53,7 @@ func TestHealthCheckManager(t *testing.T) {
 	manager.(*healthCheckManager).newPeerCheck = func(
 		upstreamConfig *config.UpstreamConfig,
 		clientGetter client.EthClientGetter,
+		metricsContainer *metrics.Container,
 	) types.Checker {
 		return mockPeerChecker
 	}

--- a/internal/checks/manager_test.go
+++ b/internal/checks/manager_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/satsuma-data/node-gateway/internal/client"
 	"github.com/satsuma-data/node-gateway/internal/config"
+	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/mocks"
 	"github.com/satsuma-data/node-gateway/internal/types"
 
@@ -38,11 +39,14 @@ func TestHealthCheckManager(t *testing.T) {
 	tickerChan := make(chan time.Time)
 	ticker := &time.Ticker{C: tickerChan}
 
-	manager := NewHealthCheckManager(mockEthClientGetter, configs, nil, ticker)
+	metricsContainer := metrics.NewContainer()
+
+	manager := NewHealthCheckManager(mockEthClientGetter, configs, nil, ticker, metricsContainer)
 	manager.(*healthCheckManager).newBlockHeightCheck = func(
 		*config.UpstreamConfig,
 		client.EthClientGetter,
 		BlockHeightObserver,
+		*metrics.Container,
 	) types.BlockHeightChecker {
 		return mockBlockHeightChecker
 	}

--- a/internal/checks/peers_test.go
+++ b/internal/checks/peers_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestPeerChecker(t *testing.T) {
 	ethClient := mocks.NewEthClient(t)
-	ethClient.On("PeerCount", mock.Anything).Return(uint64(6), nil)
+	ethClient.EXPECT().PeerCount(mock.Anything).Return(uint64(6), nil)
 
 	mockEthClientGetter := func(url string, credentials *client.BasicAuthCredentials) (client.EthClient, error) {
 		return ethClient, nil
@@ -48,7 +48,7 @@ func TestPeerChecker(t *testing.T) {
 
 func TestPeerChecker_MethodNotSupported(t *testing.T) {
 	ethClient := mocks.NewEthClient(t)
-	ethClient.On("PeerCount", mock.Anything).Return(uint64(0), methodNotSupportedError{})
+	ethClient.EXPECT().PeerCount(mock.Anything).Return(uint64(0), methodNotSupportedError{})
 
 	mockEthClientGetter := func(url string, credentials *client.BasicAuthCredentials) (client.EthClient, error) {
 		return ethClient, nil

--- a/internal/checks/peers_test.go
+++ b/internal/checks/peers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/satsuma-data/node-gateway/internal/client"
+	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -18,7 +19,7 @@ func TestPeerChecker(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter)
+	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer())
 
 	assert.True(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "PeerCount", 1)
@@ -53,7 +54,7 @@ func TestPeerChecker_MethodNotSupported(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter)
+	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer())
 
 	assert.True(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "PeerCount", 1)

--- a/internal/checks/syncing_test.go
+++ b/internal/checks/syncing_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/satsuma-data/node-gateway/internal/client"
+	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -19,7 +20,7 @@ func TestSyncingChecker(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter)
+	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer())
 
 	assert.False(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "SyncProgress", 1)
@@ -47,7 +48,7 @@ func TestSyncingChecker_MethodNotSupported(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter)
+	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer())
 
 	assert.True(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "SyncProgress", 1)

--- a/internal/client/ethereum_client.go
+++ b/internal/client/ethereum_client.go
@@ -23,7 +23,7 @@ type NewHeadHandler struct {
 	OnError   func(failure string)
 }
 
-//go:generate mockery --output ../mocks --name EthClient
+//go:generate mockery --output ../mocks --name EthClient --with-expecter
 type EthClient interface {
 	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -253,6 +253,7 @@ type Container struct {
 	UpstreamRPCRequestErrorsTotal     *prometheus.CounterVec
 	UpstreamJSONRPCRequestErrorsTotal *prometheus.CounterVec
 	UpstreamRPCDuration               prometheus.ObserverVec
+	BlockHeight                       *prometheus.GaugeVec
 }
 
 func NewContainer() *Container {
@@ -263,6 +264,7 @@ func NewContainer() *Container {
 	result.UpstreamRPCRequestErrorsTotal = upstreamRPCRequestErrorsTotal.MustCurryWith(presetLabels)
 	result.UpstreamJSONRPCRequestErrorsTotal = upstreamJSONRPCRequestErrorsTotal.MustCurryWith(presetLabels)
 	result.UpstreamRPCDuration = upstreamRPCDuration.MustCurryWith(presetLabels)
+	result.BlockHeight = BlockHeight.MustCurryWith(presetLabels)
 	return result
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -205,7 +205,7 @@ var (
 	)
 
 	// Use 0 or 1
-	SyncStatus = promauto.NewGaugeVec(
+	syncStatus = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -215,7 +215,7 @@ var (
 		[]string{"upstream_id", "url"},
 	)
 
-	SyncStatusCheckRequests = promauto.NewCounterVec(
+	syncStatusCheckRequests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -225,7 +225,7 @@ var (
 		[]string{"upstream_id", "url"},
 	)
 
-	SyncStatusCheckDuration = promauto.NewHistogramVec(
+	syncStatusCheckDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -236,7 +236,7 @@ var (
 		[]string{"upstream_id", "url"},
 	)
 
-	SyncStatusCheckErrors = promauto.NewCounterVec(
+	syncStatusCheckErrors = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -290,10 +290,10 @@ func NewContainer() *Container {
 	result.PeerCountCheckDuration = peerCountCheckDuration.MustCurryWith(presetLabels)
 	result.PeerCountCheckErrors = peerCountCheckErrors.MustCurryWith(presetLabels)
 
-	result.SyncStatus = SyncStatus.MustCurryWith(presetLabels)
-	result.SyncStatusCheckRequests = SyncStatusCheckRequests.MustCurryWith(presetLabels)
-	result.SyncStatusCheckDuration = SyncStatusCheckDuration.MustCurryWith(presetLabels)
-	result.SyncStatusCheckErrors = SyncStatusCheckErrors.MustCurryWith(presetLabels)
+	result.SyncStatus = syncStatus.MustCurryWith(presetLabels)
+	result.SyncStatusCheckRequests = syncStatusCheckRequests.MustCurryWith(presetLabels)
+	result.SyncStatusCheckDuration = syncStatusCheckDuration.MustCurryWith(presetLabels)
+	result.SyncStatusCheckErrors = syncStatusCheckErrors.MustCurryWith(presetLabels)
 
 	return result
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -122,7 +122,7 @@ var (
 
 	// Health check metrics
 
-	BlockHeight = promauto.NewGaugeVec(
+	blockHeight = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -132,7 +132,7 @@ var (
 		[]string{"upstream_id", "url"},
 	)
 
-	BlockHeightCheckRequests = promauto.NewCounterVec(
+	blockHeightCheckRequests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -142,7 +142,7 @@ var (
 		[]string{"upstream_id", "url"},
 	)
 
-	BlockHeightCheckDuration = promauto.NewHistogramVec(
+	blockHeightCheckDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -153,7 +153,7 @@ var (
 		[]string{"upstream_id", "url"},
 	)
 
-	BlockHeightCheckErrors = promauto.NewCounterVec(
+	blockHeightCheckErrors = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -267,10 +267,10 @@ func NewContainer() *Container {
 	result.UpstreamRPCRequestErrorsTotal = upstreamRPCRequestErrorsTotal.MustCurryWith(presetLabels)
 	result.UpstreamJSONRPCRequestErrorsTotal = upstreamJSONRPCRequestErrorsTotal.MustCurryWith(presetLabels)
 	result.UpstreamRPCDuration = upstreamRPCDuration.MustCurryWith(presetLabels)
-	result.BlockHeight = BlockHeight.MustCurryWith(presetLabels)
-	result.BlockHeightCheckRequests = BlockHeightCheckRequests.MustCurryWith(presetLabels)
-	result.BlockHeightCheckDuration = BlockHeightCheckDuration.MustCurryWith(presetLabels)
-	result.BlockHeightCheckErrors = BlockHeightCheckErrors.MustCurryWith(presetLabels)
+	result.BlockHeight = blockHeight.MustCurryWith(presetLabels)
+	result.BlockHeightCheckRequests = blockHeightCheckRequests.MustCurryWith(presetLabels)
+	result.BlockHeightCheckDuration = blockHeightCheckDuration.MustCurryWith(presetLabels)
+	result.BlockHeightCheckErrors = blockHeightCheckErrors.MustCurryWith(presetLabels)
 	return result
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -63,7 +63,7 @@ var (
 
 	// Upstream routing metrics
 
-	UpstreamRPCRequestsTotal = promauto.NewCounterVec(
+	upstreamRPCRequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "router",
@@ -74,7 +74,7 @@ var (
 		[]string{"client", "upstream_id", "url", "jsonrpc_method"},
 	)
 
-	UpstreamJSONRPCRequestsTotal = promauto.NewCounterVec(
+	upstreamJSONRPCRequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "router",
@@ -85,7 +85,7 @@ var (
 		[]string{"client", "upstream_id", "url", "jsonrpc_method"},
 	)
 
-	UpstreamRPCRequestErrorsTotal = promauto.NewCounterVec(
+	upstreamRPCRequestErrorsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "router",
@@ -96,7 +96,7 @@ var (
 		[]string{"client", "upstream_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
 	)
 
-	UpstreamJSONRPCRequestErrorsTotal = promauto.NewCounterVec(
+	upstreamJSONRPCRequestErrorsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "router",
@@ -108,7 +108,7 @@ var (
 		[]string{"client", "upstream_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
 	)
 
-	UpstreamRPCDuration = promauto.NewHistogramVec(
+	upstreamRPCDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "router",
@@ -258,11 +258,11 @@ type Container struct {
 func NewContainer() *Container {
 	result := new(Container)
 	presetLabels := make(prometheus.Labels)
-	result.UpstreamRPCRequestsTotal = UpstreamRPCRequestsTotal.MustCurryWith(presetLabels)
-	result.UpstreamJSONRPCRequestsTotal = UpstreamJSONRPCRequestsTotal.MustCurryWith(presetLabels)
-	result.UpstreamRPCRequestErrorsTotal = UpstreamRPCRequestErrorsTotal.MustCurryWith(presetLabels)
-	result.UpstreamJSONRPCRequestErrorsTotal = UpstreamJSONRPCRequestErrorsTotal.MustCurryWith(presetLabels)
-	result.UpstreamRPCDuration = UpstreamRPCDuration.MustCurryWith(presetLabels)
+	result.UpstreamRPCRequestsTotal = upstreamRPCRequestsTotal.MustCurryWith(presetLabels)
+	result.UpstreamJSONRPCRequestsTotal = upstreamJSONRPCRequestsTotal.MustCurryWith(presetLabels)
+	result.UpstreamRPCRequestErrorsTotal = upstreamRPCRequestErrorsTotal.MustCurryWith(presetLabels)
+	result.UpstreamJSONRPCRequestErrorsTotal = upstreamJSONRPCRequestErrorsTotal.MustCurryWith(presetLabels)
+	result.UpstreamRPCDuration = upstreamRPCDuration.MustCurryWith(presetLabels)
 	return result
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -247,6 +247,13 @@ var (
 	)
 )
 
+type Container struct {
+}
+
+func NewContainer() *Container {
+	return new(Container)
+}
+
 func NewMetricsServer() *http.Server {
 	mux := http.NewServeMux()
 	mux.Handle("/", promhttp.Handler())

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -253,10 +253,16 @@ type Container struct {
 	UpstreamRPCRequestErrorsTotal     *prometheus.CounterVec
 	UpstreamJSONRPCRequestErrorsTotal *prometheus.CounterVec
 	UpstreamRPCDuration               prometheus.ObserverVec
-	BlockHeight                       *prometheus.GaugeVec
-	BlockHeightCheckRequests          *prometheus.CounterVec
-	BlockHeightCheckDuration          prometheus.ObserverVec
-	BlockHeightCheckErrors            *prometheus.CounterVec
+
+	BlockHeight              *prometheus.GaugeVec
+	BlockHeightCheckRequests *prometheus.CounterVec
+	BlockHeightCheckDuration prometheus.ObserverVec
+	BlockHeightCheckErrors   *prometheus.CounterVec
+
+	PeerCount              *prometheus.GaugeVec
+	PeerCountCheckRequests *prometheus.CounterVec
+	PeerCountCheckDuration prometheus.ObserverVec
+	PeerCountCheckErrors   *prometheus.CounterVec
 }
 
 func NewContainer() *Container {
@@ -267,10 +273,17 @@ func NewContainer() *Container {
 	result.UpstreamRPCRequestErrorsTotal = upstreamRPCRequestErrorsTotal.MustCurryWith(presetLabels)
 	result.UpstreamJSONRPCRequestErrorsTotal = upstreamJSONRPCRequestErrorsTotal.MustCurryWith(presetLabels)
 	result.UpstreamRPCDuration = upstreamRPCDuration.MustCurryWith(presetLabels)
+
 	result.BlockHeight = blockHeight.MustCurryWith(presetLabels)
 	result.BlockHeightCheckRequests = blockHeightCheckRequests.MustCurryWith(presetLabels)
 	result.BlockHeightCheckDuration = blockHeightCheckDuration.MustCurryWith(presetLabels)
 	result.BlockHeightCheckErrors = blockHeightCheckErrors.MustCurryWith(presetLabels)
+
+	result.PeerCount = PeerCount.MustCurryWith(presetLabels)
+	result.PeerCountCheckRequests = PeerCountCheckRequests.MustCurryWith(presetLabels)
+	result.PeerCountCheckDuration = PeerCountCheckDuration.MustCurryWith(presetLabels)
+	result.PeerCountCheckErrors = PeerCountCheckErrors.MustCurryWith(presetLabels)
+
 	return result
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -163,7 +163,7 @@ var (
 		[]string{"upstream_id", "url", "errorType"},
 	)
 
-	PeerCount = promauto.NewGaugeVec(
+	peerCount = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -173,7 +173,7 @@ var (
 		[]string{"upstream_id", "url"},
 	)
 
-	PeerCountCheckRequests = promauto.NewCounterVec(
+	peerCountCheckRequests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -183,7 +183,7 @@ var (
 		[]string{"upstream_id", "url"},
 	)
 
-	PeerCountCheckDuration = promauto.NewHistogramVec(
+	peerCountCheckDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -194,7 +194,7 @@ var (
 		[]string{"upstream_id", "url"},
 	)
 
-	PeerCountCheckErrors = promauto.NewCounterVec(
+	peerCountCheckErrors = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: "healthcheck",
@@ -279,10 +279,10 @@ func NewContainer() *Container {
 	result.BlockHeightCheckDuration = blockHeightCheckDuration.MustCurryWith(presetLabels)
 	result.BlockHeightCheckErrors = blockHeightCheckErrors.MustCurryWith(presetLabels)
 
-	result.PeerCount = PeerCount.MustCurryWith(presetLabels)
-	result.PeerCountCheckRequests = PeerCountCheckRequests.MustCurryWith(presetLabels)
-	result.PeerCountCheckDuration = PeerCountCheckDuration.MustCurryWith(presetLabels)
-	result.PeerCountCheckErrors = PeerCountCheckErrors.MustCurryWith(presetLabels)
+	result.PeerCount = peerCount.MustCurryWith(presetLabels)
+	result.PeerCountCheckRequests = peerCountCheckRequests.MustCurryWith(presetLabels)
+	result.PeerCountCheckDuration = peerCountCheckDuration.MustCurryWith(presetLabels)
+	result.PeerCountCheckErrors = peerCountCheckErrors.MustCurryWith(presetLabels)
 
 	return result
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -263,11 +263,17 @@ type Container struct {
 	PeerCountCheckRequests *prometheus.CounterVec
 	PeerCountCheckDuration prometheus.ObserverVec
 	PeerCountCheckErrors   *prometheus.CounterVec
+
+	SyncStatus              *prometheus.GaugeVec
+	SyncStatusCheckRequests *prometheus.CounterVec
+	SyncStatusCheckDuration prometheus.ObserverVec
+	SyncStatusCheckErrors   *prometheus.CounterVec
 }
 
 func NewContainer() *Container {
 	result := new(Container)
 	presetLabels := make(prometheus.Labels)
+
 	result.UpstreamRPCRequestsTotal = upstreamRPCRequestsTotal.MustCurryWith(presetLabels)
 	result.UpstreamJSONRPCRequestsTotal = upstreamJSONRPCRequestsTotal.MustCurryWith(presetLabels)
 	result.UpstreamRPCRequestErrorsTotal = upstreamRPCRequestErrorsTotal.MustCurryWith(presetLabels)
@@ -283,6 +289,11 @@ func NewContainer() *Container {
 	result.PeerCountCheckRequests = peerCountCheckRequests.MustCurryWith(presetLabels)
 	result.PeerCountCheckDuration = peerCountCheckDuration.MustCurryWith(presetLabels)
 	result.PeerCountCheckErrors = peerCountCheckErrors.MustCurryWith(presetLabels)
+
+	result.SyncStatus = SyncStatus.MustCurryWith(presetLabels)
+	result.SyncStatusCheckRequests = SyncStatusCheckRequests.MustCurryWith(presetLabels)
+	result.SyncStatusCheckDuration = SyncStatusCheckDuration.MustCurryWith(presetLabels)
+	result.SyncStatusCheckErrors = SyncStatusCheckErrors.MustCurryWith(presetLabels)
 
 	return result
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -254,6 +254,9 @@ type Container struct {
 	UpstreamJSONRPCRequestErrorsTotal *prometheus.CounterVec
 	UpstreamRPCDuration               prometheus.ObserverVec
 	BlockHeight                       *prometheus.GaugeVec
+	BlockHeightCheckRequests          *prometheus.CounterVec
+	BlockHeightCheckDuration          prometheus.ObserverVec
+	BlockHeightCheckErrors            *prometheus.CounterVec
 }
 
 func NewContainer() *Container {
@@ -265,6 +268,9 @@ func NewContainer() *Container {
 	result.UpstreamJSONRPCRequestErrorsTotal = upstreamJSONRPCRequestErrorsTotal.MustCurryWith(presetLabels)
 	result.UpstreamRPCDuration = upstreamRPCDuration.MustCurryWith(presetLabels)
 	result.BlockHeight = BlockHeight.MustCurryWith(presetLabels)
+	result.BlockHeightCheckRequests = BlockHeightCheckRequests.MustCurryWith(presetLabels)
+	result.BlockHeightCheckDuration = BlockHeightCheckDuration.MustCurryWith(presetLabels)
+	result.BlockHeightCheckErrors = BlockHeightCheckErrors.MustCurryWith(presetLabels)
 	return result
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -248,10 +248,22 @@ var (
 )
 
 type Container struct {
+	UpstreamRPCRequestsTotal          *prometheus.CounterVec
+	UpstreamJSONRPCRequestsTotal      *prometheus.CounterVec
+	UpstreamRPCRequestErrorsTotal     *prometheus.CounterVec
+	UpstreamJSONRPCRequestErrorsTotal *prometheus.CounterVec
+	UpstreamRPCDuration               prometheus.ObserverVec
 }
 
 func NewContainer() *Container {
-	return new(Container)
+	result := new(Container)
+	presetLabels := make(prometheus.Labels)
+	result.UpstreamRPCRequestsTotal = UpstreamRPCRequestsTotal.MustCurryWith(presetLabels)
+	result.UpstreamJSONRPCRequestsTotal = UpstreamJSONRPCRequestsTotal.MustCurryWith(presetLabels)
+	result.UpstreamRPCRequestErrorsTotal = UpstreamRPCRequestErrorsTotal.MustCurryWith(presetLabels)
+	result.UpstreamJSONRPCRequestErrorsTotal = UpstreamJSONRPCRequestErrorsTotal.MustCurryWith(presetLabels)
+	result.UpstreamRPCDuration = UpstreamRPCDuration.MustCurryWith(presetLabels)
+	return result
 }
 
 func NewMetricsServer() *http.Server {

--- a/internal/mocks/EthClient.go
+++ b/internal/mocks/EthClient.go
@@ -19,6 +19,14 @@ type EthClient struct {
 	mock.Mock
 }
 
+type EthClient_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *EthClient) EXPECT() *EthClient_Expecter {
+	return &EthClient_Expecter{mock: &_m.Mock}
+}
+
 // HeaderByNumber provides a mock function with given fields: ctx, number
 func (_m *EthClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	ret := _m.Called(ctx, number)
@@ -42,6 +50,30 @@ func (_m *EthClient) HeaderByNumber(ctx context.Context, number *big.Int) (*type
 	return r0, r1
 }
 
+// EthClient_HeaderByNumber_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HeaderByNumber'
+type EthClient_HeaderByNumber_Call struct {
+	*mock.Call
+}
+
+// HeaderByNumber is a helper method to define mock.On call
+//   - ctx context.Context
+//   - number *big.Int
+func (_e *EthClient_Expecter) HeaderByNumber(ctx interface{}, number interface{}) *EthClient_HeaderByNumber_Call {
+	return &EthClient_HeaderByNumber_Call{Call: _e.mock.On("HeaderByNumber", ctx, number)}
+}
+
+func (_c *EthClient_HeaderByNumber_Call) Run(run func(ctx context.Context, number *big.Int)) *EthClient_HeaderByNumber_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*big.Int))
+	})
+	return _c
+}
+
+func (_c *EthClient_HeaderByNumber_Call) Return(_a0 *types.Header, _a1 error) *EthClient_HeaderByNumber_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
 // PeerCount provides a mock function with given fields: ctx
 func (_m *EthClient) PeerCount(ctx context.Context) (uint64, error) {
 	ret := _m.Called(ctx)
@@ -61,6 +93,29 @@ func (_m *EthClient) PeerCount(ctx context.Context) (uint64, error) {
 	}
 
 	return r0, r1
+}
+
+// EthClient_PeerCount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PeerCount'
+type EthClient_PeerCount_Call struct {
+	*mock.Call
+}
+
+// PeerCount is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *EthClient_Expecter) PeerCount(ctx interface{}) *EthClient_PeerCount_Call {
+	return &EthClient_PeerCount_Call{Call: _e.mock.On("PeerCount", ctx)}
+}
+
+func (_c *EthClient_PeerCount_Call) Run(run func(ctx context.Context)) *EthClient_PeerCount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *EthClient_PeerCount_Call) Return(_a0 uint64, _a1 error) *EthClient_PeerCount_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
 }
 
 // SubscribeNewHead provides a mock function with given fields: ctx, ch
@@ -86,6 +141,30 @@ func (_m *EthClient) SubscribeNewHead(ctx context.Context, ch chan<- *types.Head
 	return r0, r1
 }
 
+// EthClient_SubscribeNewHead_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SubscribeNewHead'
+type EthClient_SubscribeNewHead_Call struct {
+	*mock.Call
+}
+
+// SubscribeNewHead is a helper method to define mock.On call
+//   - ctx context.Context
+//   - ch chan<- *types.Header
+func (_e *EthClient_Expecter) SubscribeNewHead(ctx interface{}, ch interface{}) *EthClient_SubscribeNewHead_Call {
+	return &EthClient_SubscribeNewHead_Call{Call: _e.mock.On("SubscribeNewHead", ctx, ch)}
+}
+
+func (_c *EthClient_SubscribeNewHead_Call) Run(run func(ctx context.Context, ch chan<- *types.Header)) *EthClient_SubscribeNewHead_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(chan<- *types.Header))
+	})
+	return _c
+}
+
+func (_c *EthClient_SubscribeNewHead_Call) Return(_a0 ethereum.Subscription, _a1 error) *EthClient_SubscribeNewHead_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
 // SyncProgress provides a mock function with given fields: ctx
 func (_m *EthClient) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
 	ret := _m.Called(ctx)
@@ -107,6 +186,29 @@ func (_m *EthClient) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, 
 	}
 
 	return r0, r1
+}
+
+// EthClient_SyncProgress_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SyncProgress'
+type EthClient_SyncProgress_Call struct {
+	*mock.Call
+}
+
+// SyncProgress is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *EthClient_Expecter) SyncProgress(ctx interface{}) *EthClient_SyncProgress_Call {
+	return &EthClient_SyncProgress_Call{Call: _e.mock.On("SyncProgress", ctx)}
+}
+
+func (_c *EthClient_SyncProgress_Call) Run(run func(ctx context.Context)) *EthClient_SyncProgress_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *EthClient_SyncProgress_Call) Return(_a0 *ethereum.SyncProgress, _a1 error) *EthClient_SyncProgress_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
 }
 
 type mockConstructorTestingTNewEthClient interface {

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -141,7 +141,7 @@ func (r *SimpleRouter) Route(
 
 	go func() {
 		for _, request := range requestBody.GetSubRequests() {
-			metrics.UpstreamJSONRPCRequestsTotal.WithLabelValues(
+			r.metricsContainer.UpstreamJSONRPCRequestsTotal.WithLabelValues(
 				util.GetClientFromContext(ctx),
 				id,
 				configToRoute.HTTPURL,
@@ -159,7 +159,7 @@ func (r *SimpleRouter) Route(
 	}
 
 	if err != nil {
-		metrics.UpstreamRPCRequestErrorsTotal.WithLabelValues(
+		r.metricsContainer.UpstreamRPCRequestErrorsTotal.WithLabelValues(
 			util.GetClientFromContext(ctx),
 			id,
 			configToRoute.HTTPURL,
@@ -183,7 +183,7 @@ func (r *SimpleRouter) Route(
 					zap.Any("request", requestBody), zap.Any("error", resp.Error),
 					zap.String("client", util.GetClientFromContext(ctx)), zap.String("upstreamID", id))
 
-				metrics.UpstreamJSONRPCRequestErrorsTotal.WithLabelValues(
+				r.metricsContainer.UpstreamJSONRPCRequestErrorsTotal.WithLabelValues(
 					util.GetClientFromContext(ctx),
 					id,
 					configToRoute.HTTPURL,
@@ -195,7 +195,7 @@ func (r *SimpleRouter) Route(
 		}
 	}
 
-	metrics.UpstreamRPCDuration.WithLabelValues(
+	r.metricsContainer.UpstreamRPCDuration.WithLabelValues(
 		util.GetClientFromContext(ctx),
 		configToRoute.ID,
 		configToRoute.HTTPURL,

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -38,11 +38,11 @@ type SimpleRouter struct {
 	healthCheckManager checks.HealthCheckManager
 	routingStrategy    RoutingStrategy
 	requestExecutor    RequestExecutor
+	metricsContainer   *metrics.Container
 	// Map from Priority => UpstreamIDs
 	priorityToUpstreams types.PriorityToUpstreamsMap
 	metadataParser      metadata.RequestMetadataParser
 	upstreamConfigs     []config.UpstreamConfig
-	metricsContainer    *metrics.Container
 }
 
 func NewRouter(

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -42,6 +42,7 @@ type SimpleRouter struct {
 	priorityToUpstreams types.PriorityToUpstreamsMap
 	metadataParser      metadata.RequestMetadataParser
 	upstreamConfigs     []config.UpstreamConfig
+	metricsContainer    *metrics.Container
 }
 
 func NewRouter(
@@ -50,6 +51,7 @@ func NewRouter(
 	chainMetadataStore *metadata.ChainMetadataStore,
 	healthCheckManager checks.HealthCheckManager,
 	routingStrategy RoutingStrategy,
+	metricsContainer *metrics.Container,
 ) Router {
 	r := &SimpleRouter{
 		chainMetadataStore:  chainMetadataStore,
@@ -59,6 +61,7 @@ func NewRouter(
 		routingStrategy:     routingStrategy,
 		requestExecutor:     RequestExecutor{httpClient: &http.Client{}},
 		metadataParser:      metadata.RequestMetadataParser{},
+		metricsContainer:    metricsContainer,
 	}
 
 	return r

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -130,7 +130,7 @@ func (r *SimpleRouter) Route(
 		}
 	}
 
-	metrics.UpstreamRPCRequestsTotal.WithLabelValues(
+	r.metricsContainer.UpstreamRPCRequestsTotal.WithLabelValues(
 		util.GetClientFromContext(ctx),
 		id,
 		configToRoute.HTTPURL,

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/satsuma-data/node-gateway/internal/metadata"
+	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/types"
 
 	"github.com/satsuma-data/node-gateway/internal/config"
@@ -33,7 +34,7 @@ func TestRouter_NoHealthyUpstreams(t *testing.T) {
 	routingStrategy := mocks.NewMockRoutingStrategy(t)
 	routingStrategy.EXPECT().RouteNextRequest(mock.Anything, mock.Anything).Return("", ErrNoHealthyUpstreams)
 
-	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, routingStrategy)
+	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, routingStrategy, metrics.NewContainer())
 	router.(*SimpleRouter).healthCheckManager = managerMock
 	router.Start()
 
@@ -106,7 +107,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 			Priority: 2,
 		},
 	}
-	router := NewRouter(upstreamConfigs, groupConfigs, metadata.NewChainMetadataStore(), managerMock, nil)
+	router := NewRouter(upstreamConfigs, groupConfigs, metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer())
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
@@ -151,7 +152,7 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 		erigonConfig,
 	}
 
-	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, nil)
+	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer())
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -77,8 +77,9 @@ func wireRouter(config conf.Config) route.Router {
 		NodeFilter:      nodeFilter,
 		BackingStrategy: route.NewPriorityRoundRobinStrategy(),
 	}
+	metricContainer := metrics.NewContainer()
 
-	return route.NewRouter(config.Upstreams, config.Groups, chainMetadataStore, healthCheckManager, &routingStrategy)
+	return route.NewRouter(config.Upstreams, config.Groups, chainMetadataStore, healthCheckManager, &routingStrategy, metricContainer)
 }
 
 func (s *RPCServer) Start() error {

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestServeHTTP_ForwardsToSoleHealthyUpstream(t *testing.T) {
@@ -257,7 +256,7 @@ func executeRequest(t *testing.T, request jsonrpc.RequestBody, handler *RPCHandl
 }
 
 func startRouterAndHandler(conf config.Config) *RPCHandler {
-	dependencyContainer := wireDependencies(conf, zap.L())
+	dependencyContainer := wireDependencies(conf)
 	router := dependencyContainer.router
 	router.Start()
 

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestServeHTTP_ForwardsToSoleHealthyUpstream(t *testing.T) {
@@ -256,7 +257,8 @@ func executeRequest(t *testing.T, request jsonrpc.RequestBody, handler *RPCHandl
 }
 
 func startRouterAndHandler(conf config.Config) *RPCHandler {
-	router := wireRouter(conf)
+	dependencyContainer := wireDependencies(conf, zap.L())
+	router := dependencyContainer.router
 	router.Start()
 
 	for router.IsInitialized() == false {


### PR DESCRIPTION
# Description

This PR introduces a `MetricContainer` that can be used to pre-fill a set of metric labels. It'll be used in a follow-up PR to create a separate container per chain to enable multi-chain support.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

1. Started a metric server in one of the e2e tests
2. Added a `time.Sleep` at the end
3. Queried the metrics endpoint and verified that metrics are still emitted correctly.
