### PR TITLE
refactor: pass logger into object graph

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -58,7 +58,7 @@ func main() {
 	zap.L().Info("Starting node gateway.", zap.String("env", env), zap.Any("config", conf))
 
 	go func() {
-		rpcServer = server.NewRPCServer(conf)
+		rpcServer = server.NewRPCServer(conf, logger)
 
 		if err := rpcServer.Start(); err != http.ErrServerClosed {
 			zap.L().Fatal("Failed to start RPC server.", zap.Error(err))

--- a/internal/checks/blockheight_test.go
+++ b/internal/checks/blockheight_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/satsuma-data/node-gateway/internal/metadata"
 	"github.com/satsuma-data/node-gateway/internal/metrics"
+	"go.uber.org/zap"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/satsuma-data/node-gateway/internal/client"
@@ -37,7 +38,7 @@ func TestBlockHeightChecker_WS(t *testing.T) {
 	chainMetadataStore := metadata.NewChainMetadataStore()
 	chainMetadataStore.Start()
 
-	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer())
+	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer(), zap.L())
 
 	ethClient.AssertNumberOfCalls(t, "SubscribeNewHead", 1)
 
@@ -65,7 +66,7 @@ func TestBlockHeightChecker_WSSubscribeFailed(t *testing.T) {
 	chainMetadataStore := metadata.NewChainMetadataStore()
 	chainMetadataStore.Start()
 
-	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer())
+	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer(), zap.L())
 
 	ethClient.AssertNumberOfCalls(t, "SubscribeNewHead", 1)
 	assert.False(t, checker.IsPassing(maxBlockHeight))
@@ -100,7 +101,7 @@ func TestBlockHeightChecker_HTTP(t *testing.T) {
 		chainMetadataStore := metadata.NewChainMetadataStore()
 		chainMetadataStore.Start()
 
-		checker := NewBlockHeightChecker(config, mockEthClientGetter, chainMetadataStore, metrics.NewContainer())
+		checker := NewBlockHeightChecker(config, mockEthClientGetter, chainMetadataStore, metrics.NewContainer(), zap.L())
 
 		checker.RunCheck()
 		ethClient.AssertNumberOfCalls(t, "SubscribeNewHead", 0)
@@ -119,6 +120,7 @@ func TestBlockHeightChecker_IsPassing(t *testing.T) {
 		{
 			name: "No errors, block height high enough.",
 			blockHeightCheck: BlockHeightCheck{
+				logger:         zap.L(),
 				upstreamConfig: defaultUpstreamConfig,
 				blockHeight:    3,
 			},
@@ -128,6 +130,7 @@ func TestBlockHeightChecker_IsPassing(t *testing.T) {
 		{
 			name: "No errors, block height too low.",
 			blockHeightCheck: BlockHeightCheck{
+				logger:         zap.L(),
 				upstreamConfig: defaultUpstreamConfig,
 				blockHeight:    2,
 			},
@@ -137,6 +140,7 @@ func TestBlockHeightChecker_IsPassing(t *testing.T) {
 		{
 			name: "Errors found, block height high enough.",
 			blockHeightCheck: BlockHeightCheck{
+				logger:           zap.L(),
 				blockHeightError: errors.New("an error"),
 				upstreamConfig:   defaultUpstreamConfig,
 				blockHeight:      3,

--- a/internal/checks/manager_test.go
+++ b/internal/checks/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/mocks"
 	"github.com/satsuma-data/node-gateway/internal/types"
+	"go.uber.org/zap"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -41,12 +42,13 @@ func TestHealthCheckManager(t *testing.T) {
 
 	metricsContainer := metrics.NewContainer()
 
-	manager := NewHealthCheckManager(mockEthClientGetter, configs, nil, ticker, metricsContainer)
+	manager := NewHealthCheckManager(mockEthClientGetter, configs, nil, ticker, metricsContainer, zap.L())
 	manager.(*healthCheckManager).newBlockHeightCheck = func(
 		*config.UpstreamConfig,
 		client.EthClientGetter,
 		BlockHeightObserver,
 		*metrics.Container,
+		*zap.Logger,
 	) types.BlockHeightChecker {
 		return mockBlockHeightChecker
 	}
@@ -54,6 +56,7 @@ func TestHealthCheckManager(t *testing.T) {
 		upstreamConfig *config.UpstreamConfig,
 		clientGetter client.EthClientGetter,
 		metricsContainer *metrics.Container,
+		logger *zap.Logger,
 	) types.Checker {
 		return mockPeerChecker
 	}
@@ -61,6 +64,7 @@ func TestHealthCheckManager(t *testing.T) {
 		upstreamConfig *config.UpstreamConfig,
 		clientGetter client.EthClientGetter,
 		metricsContainer *metrics.Container,
+		logger *zap.Logger,
 	) types.Checker {
 		return mockSyncingChecker
 	}

--- a/internal/checks/peers.go
+++ b/internal/checks/peers.go
@@ -15,10 +15,10 @@ type PeerCheck struct {
 	Err              error
 	clientGetter     client.EthClientGetter
 	metricsContainer *metrics.Container
+	logger           *zap.Logger
 	upstreamConfig   *conf.UpstreamConfig
 	PeerCount        uint64
 	ShouldRun        bool
-	logger           *zap.Logger
 }
 
 func NewPeerChecker(

--- a/internal/checks/peers_test.go
+++ b/internal/checks/peers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 )
 
 func TestPeerChecker(t *testing.T) {
@@ -19,7 +20,7 @@ func TestPeerChecker(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer())
+	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer(), zap.L())
 
 	assert.True(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "PeerCount", 1)
@@ -54,7 +55,7 @@ func TestPeerChecker_MethodNotSupported(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer())
+	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer(), zap.L())
 
 	assert.True(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "PeerCount", 1)

--- a/internal/checks/syncing.go
+++ b/internal/checks/syncing.go
@@ -15,16 +15,19 @@ type SyncingCheck struct {
 	Err              error
 	clientGetter     client.EthClientGetter
 	metricsContainer *metrics.Container
-	upstreamConfig   *conf.UpstreamConfig
-	IsSyncing        bool
-	ShouldRun        bool
+	logger           *zap.Logger
+
+	upstreamConfig *conf.UpstreamConfig
+	IsSyncing      bool
+	ShouldRun      bool
 }
 
-func NewSyncingChecker(upstreamConfig *conf.UpstreamConfig, clientGetter client.EthClientGetter, metricsContainer *metrics.Container) types.Checker {
+func NewSyncingChecker(upstreamConfig *conf.UpstreamConfig, clientGetter client.EthClientGetter, metricsContainer *metrics.Container, logger *zap.Logger) types.Checker {
 	c := &SyncingCheck{
 		upstreamConfig:   upstreamConfig,
 		clientGetter:     clientGetter,
 		metricsContainer: metricsContainer,
+		logger:           logger,
 		// Set `isSyncing:true` until we check the upstream node's syncing status.
 		IsSyncing: true,
 		// Set `ShouldRun:true` until we verify `eth.syncing` is a supported method of the Upstream.
@@ -32,14 +35,14 @@ func NewSyncingChecker(upstreamConfig *conf.UpstreamConfig, clientGetter client.
 	}
 
 	if err := c.Initialize(); err != nil {
-		zap.L().Error("Error initializing SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Error(err))
+		logger.Error("Error initializing SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Error(err))
 	}
 
 	return c
 }
 
 func (c *SyncingCheck) Initialize() error {
-	zap.L().Debug("Initializing SyncingCheck.", zap.Any("config", c.upstreamConfig))
+	c.logger.Debug("Initializing SyncingCheck.", zap.Any("config", c.upstreamConfig))
 
 	httpClient, err := c.clientGetter(c.upstreamConfig.HTTPURL, &client.BasicAuthCredentials{Username: c.upstreamConfig.BasicAuthConfig.Username, Password: c.upstreamConfig.BasicAuthConfig.Password})
 	if err != nil {
@@ -52,7 +55,7 @@ func (c *SyncingCheck) Initialize() error {
 	c.runCheck()
 
 	if isMethodNotSupportedErr(c.Err) {
-		zap.L().Debug("PeerCheck is not supported by upstream, not running check.", zap.Any("upstreamID", c.upstreamConfig.ID))
+		c.logger.Debug("PeerCheck is not supported by upstream, not running check.", zap.Any("upstreamID", c.upstreamConfig.ID))
 
 		c.ShouldRun = false
 	}
@@ -63,7 +66,7 @@ func (c *SyncingCheck) Initialize() error {
 func (c *SyncingCheck) RunCheck() {
 	if c.client == nil {
 		if err := c.Initialize(); err != nil {
-			zap.L().Error("Error initializing SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Error(err))
+			c.logger.Error("Error initializing SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Error(err))
 			c.metricsContainer.SyncStatusCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPInit).Inc()
 		}
 	}
@@ -94,7 +97,7 @@ func (c *SyncingCheck) runCheck() {
 
 		c.metricsContainer.SyncStatus.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Set(float64(gauge))
 
-		zap.L().Debug("Ran SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Any("syncProgress", result))
+		c.logger.Debug("Ran SyncingCheck.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.Any("syncProgress", result))
 	}
 
 	runCheckWithMetrics(runCheck,
@@ -104,7 +107,7 @@ func (c *SyncingCheck) runCheck() {
 
 func (c *SyncingCheck) IsPassing() bool {
 	if c.ShouldRun && (c.IsSyncing || c.Err != nil) {
-		zap.L().Error("SyncingCheck is not passing.", zap.String("upstreamID", c.upstreamConfig.ID), zap.Any("isSyncing", c.IsSyncing), zap.Error(c.Err))
+		c.logger.Error("SyncingCheck is not passing.", zap.String("upstreamID", c.upstreamConfig.ID), zap.Any("isSyncing", c.IsSyncing), zap.Error(c.Err))
 
 		return false
 	}

--- a/internal/checks/syncing_test.go
+++ b/internal/checks/syncing_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 )
 
 func TestSyncingChecker(t *testing.T) {
@@ -20,7 +21,7 @@ func TestSyncingChecker(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer())
+	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer(), zap.L())
 
 	assert.False(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "SyncProgress", 1)
@@ -48,7 +49,7 @@ func TestSyncingChecker_MethodNotSupported(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer())
+	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer(), zap.L())
 
 	assert.True(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "SyncProgress", 1)

--- a/internal/route/filtering_strategy.go
+++ b/internal/route/filtering_strategy.go
@@ -10,6 +10,7 @@ import (
 type FilteringRoutingStrategy struct {
 	NodeFilter      NodeFilter
 	BackingStrategy RoutingStrategy
+	Logger          *zap.Logger
 }
 
 func (s *FilteringRoutingStrategy) RouteNextRequest(
@@ -27,7 +28,7 @@ func (s *FilteringRoutingStrategy) filter(
 	priorityToHealthyUpstreams := make(types.PriorityToUpstreamsMap)
 
 	for priority, upstreamConfigs := range upstreamsByPriority {
-		zap.L().Debug("Determining healthy upstreams at priority.", zap.Int("priority", priority), zap.Any("upstreams", upstreamConfigs))
+		s.Logger.Debug("Determining healthy upstreams at priority.", zap.Int("priority", priority), zap.Any("upstreams", upstreamConfigs))
 
 		filteredUpstreams := make([]*config.UpstreamConfig, 0)
 

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -16,6 +16,7 @@ type NodeFilter interface {
 type AndFilter struct {
 	filters    []NodeFilter
 	isTopLevel bool
+	logger     *zap.Logger
 }
 
 func (a *AndFilter) Apply(requestMetadata metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
@@ -32,7 +33,7 @@ func (a *AndFilter) Apply(requestMetadata metadata.RequestMetadata, upstreamConf
 	}
 
 	if result && a.isTopLevel {
-		zap.L().Debug("Upstream passed all filters for request.",
+		a.logger.Debug("Upstream passed all filters for request.",
 			zap.String("upstreamID", upstreamConfig.ID),
 			zap.Any("RequestMetadata", requestMetadata),
 		)
@@ -43,6 +44,7 @@ func (a *AndFilter) Apply(requestMetadata metadata.RequestMetadata, upstreamConf
 
 type HasEnoughPeers struct {
 	healthCheckManager checks.HealthCheckManager
+	logger             *zap.Logger
 	minimumPeerCount   uint64
 }
 
@@ -52,7 +54,7 @@ func (f *HasEnoughPeers) Apply(_ metadata.RequestMetadata, upstreamConfig *confi
 
 	if peerCheck.ShouldRun {
 		if peerCheck.Err != nil {
-			zap.L().Debug("HasEnoughPeers failed: most recent health check did not succeed.", zap.String("upstreamID", upstreamConfig.ID), zap.Error(peerCheck.Err))
+			f.logger.Debug("HasEnoughPeers failed: most recent health check did not succeed.", zap.String("upstreamID", upstreamConfig.ID), zap.Error(peerCheck.Err))
 			return false
 		}
 
@@ -60,7 +62,7 @@ func (f *HasEnoughPeers) Apply(_ metadata.RequestMetadata, upstreamConfig *confi
 			return true
 		}
 
-		zap.L().Debug("HasEnoughPeers failed.",
+		f.logger.Debug("HasEnoughPeers failed.",
 			zap.String("UpstreamID", upstreamConfig.ID),
 			zap.Uint64("MinimumPeerCount", f.minimumPeerCount),
 			zap.Uint64("ActualPeerCount", peerCheck.PeerCount),
@@ -74,6 +76,7 @@ func (f *HasEnoughPeers) Apply(_ metadata.RequestMetadata, upstreamConfig *confi
 
 type IsDoneSyncing struct {
 	healthCheckManager checks.HealthCheckManager
+	logger             *zap.Logger
 }
 
 func (f *IsDoneSyncing) Apply(_ metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
@@ -83,7 +86,7 @@ func (f *IsDoneSyncing) Apply(_ metadata.RequestMetadata, upstreamConfig *config
 
 	if isSyncingCheck.ShouldRun {
 		if isSyncingCheck.Err != nil {
-			zap.L().Debug(
+			f.logger.Debug(
 				"IsDoneSyncing failed: most recent health check did not succeed.",
 				zap.Error(isSyncingCheck.Err),
 				zap.String("UpstreamID", upstreamConfig.ID),
@@ -96,7 +99,7 @@ func (f *IsDoneSyncing) Apply(_ metadata.RequestMetadata, upstreamConfig *config
 			return true
 		}
 
-		zap.L().Debug("Upstream is still syncing!", zap.String("UpstreamID", upstreamConfig.ID))
+		f.logger.Debug("Upstream is still syncing!", zap.String("UpstreamID", upstreamConfig.ID))
 
 		return false
 	}
@@ -107,6 +110,7 @@ func (f *IsDoneSyncing) Apply(_ metadata.RequestMetadata, upstreamConfig *config
 type IsCloseToGlobalMaxHeight struct {
 	healthCheckManager checks.HealthCheckManager
 	chainMetadataStore *metadata.ChainMetadataStore
+	logger             *zap.Logger
 	maxBlocksBehind    uint64
 }
 
@@ -119,7 +123,7 @@ func (f *IsCloseToGlobalMaxHeight) Apply(
 
 	checkIsHealthy := check.GetError() == nil
 	if !checkIsHealthy {
-		zap.L().Debug("IsCloseToGlobalMaxHeight failed: most recent health check did not succeed.",
+		f.logger.Debug("IsCloseToGlobalMaxHeight failed: most recent health check did not succeed.",
 			zap.Error(check.GetError()),
 			zap.String("UpstreamID", upstreamConfig.ID),
 		)
@@ -135,7 +139,7 @@ func (f *IsCloseToGlobalMaxHeight) Apply(
 		return true
 	}
 
-	zap.L().Debug(
+	f.logger.Debug(
 		"Upstream too far behind global max height!",
 		zap.String("UpstreamID", upstreamConfig.ID),
 		zap.Uint64("UpstreamHeight", upstreamHeight),
@@ -148,6 +152,7 @@ func (f *IsCloseToGlobalMaxHeight) Apply(
 type IsAtMaxHeightForGroup struct {
 	healthCheckManager checks.HealthCheckManager
 	chainMetadataStore *metadata.ChainMetadataStore
+	logger             *zap.Logger
 }
 
 func (f *IsAtMaxHeightForGroup) Apply(_ metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
@@ -155,7 +160,7 @@ func (f *IsAtMaxHeightForGroup) Apply(_ metadata.RequestMetadata, upstreamConfig
 	check := upstreamStatus.BlockHeightCheck
 
 	if check.GetError() != nil {
-		zap.L().Debug("IsCloseToGlobalMaxHeight failed: most recent health check did not succeed.",
+		f.logger.Debug("IsCloseToGlobalMaxHeight failed: most recent health check did not succeed.",
 			zap.String("UpstreamID", upstreamConfig.ID),
 			zap.Error(check.GetError()),
 		)
@@ -168,7 +173,7 @@ func (f *IsAtMaxHeightForGroup) Apply(_ metadata.RequestMetadata, upstreamConfig
 		return true
 	}
 
-	zap.L().Debug(
+	f.logger.Debug(
 		"Upstream not at max height for group!",
 		zap.String("UpstreamID", upstreamConfig.ID),
 		zap.Uint64("UpstreamHeight", check.GetBlockHeight()),
@@ -178,7 +183,9 @@ func (f *IsAtMaxHeightForGroup) Apply(_ metadata.RequestMetadata, upstreamConfig
 	return false
 }
 
-type SimpleIsStateOrTracePresent struct{}
+type SimpleIsStateOrTracePresent struct {
+	logger *zap.Logger
+}
 
 func (f *SimpleIsStateOrTracePresent) Apply(
 	requestMetadata metadata.RequestMetadata,
@@ -189,7 +196,7 @@ func (f *SimpleIsStateOrTracePresent) Apply(
 			return true
 		}
 
-		zap.L().Debug(
+		f.logger.Debug(
 			"Upstream is not an archive node but request requires state or is a trace method!",
 			zap.String("UpstreamID", upstreamConfig.ID),
 			zap.Any("RequestMetadata", requestMetadata),
@@ -205,26 +212,29 @@ func CreateNodeFilter(
 	filterNames []NodeFilterType,
 	manager checks.HealthCheckManager,
 	store *metadata.ChainMetadataStore,
+	logger *zap.Logger,
 	routingConfig *config.RoutingConfig,
 ) NodeFilter {
 	var filters = make([]NodeFilter, len(filterNames))
 	for i := range filterNames {
-		filters[i] = CreateSingleNodeFilter(filterNames[i], manager, store, routingConfig)
+		filters[i] = CreateSingleNodeFilter(filterNames[i], manager, store, logger, routingConfig)
 	}
 
-	return &AndFilter{filters, true}
+	return &AndFilter{filters, true, logger}
 }
 
 func CreateSingleNodeFilter(
 	filterName NodeFilterType,
 	manager checks.HealthCheckManager,
 	store *metadata.ChainMetadataStore,
+	logger *zap.Logger,
 	routingConfig *config.RoutingConfig,
 ) NodeFilter {
 	switch filterName {
 	case Healthy:
 		hasEnoughPeers := HasEnoughPeers{
 			healthCheckManager: manager,
+			logger:             logger,
 			minimumPeerCount:   checks.MinimumPeerCount,
 		}
 		isDoneSyncing := IsDoneSyncing{healthCheckManager: manager}
@@ -234,6 +244,7 @@ func CreateSingleNodeFilter(
 		return &IsCloseToGlobalMaxHeight{
 			healthCheckManager: manager,
 			chainMetadataStore: store,
+			logger:             logger,
 			maxBlocksBehind:    0,
 		}
 	case NearGlobalMaxHeight:
@@ -245,15 +256,17 @@ func CreateSingleNodeFilter(
 		return &IsCloseToGlobalMaxHeight{
 			healthCheckManager: manager,
 			chainMetadataStore: store,
+			logger:             logger,
 			maxBlocksBehind:    uint64(maxBlocksBehind),
 		}
 	case MaxHeightForGroup:
 		return &IsAtMaxHeightForGroup{
 			healthCheckManager: manager,
 			chainMetadataStore: store,
+			logger:             logger,
 		}
 	case SimpleStateOrTracePresent:
-		return &SimpleIsStateOrTracePresent{}
+		return &SimpleIsStateOrTracePresent{logger: logger}
 	default:
 		panic("Unknown filter type " + filterName + "!")
 	}

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -14,9 +14,9 @@ type NodeFilter interface {
 }
 
 type AndFilter struct {
+	logger     *zap.Logger
 	filters    []NodeFilter
 	isTopLevel bool
-	logger     *zap.Logger
 }
 
 func (a *AndFilter) Apply(requestMetadata metadata.RequestMetadata, upstreamConfig *config.UpstreamConfig) bool {
@@ -220,7 +220,7 @@ func CreateNodeFilter(
 		filters[i] = CreateSingleNodeFilter(filterNames[i], manager, store, logger, routingConfig)
 	}
 
-	return &AndFilter{filters, true, logger}
+	return &AndFilter{logger: logger, filters: filters, isTopLevel: true}
 }
 
 func CreateSingleNodeFilter(

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/mocks"
 	"github.com/satsuma-data/node-gateway/internal/types"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 type AlwaysPass struct{}
@@ -76,6 +77,7 @@ func TestIsCloseToGlobalMaxHeight_Apply(t *testing.T) {
 	filter := IsCloseToGlobalMaxHeight{
 		healthCheckManager: healthCheckManager,
 		chainMetadataStore: chainMetadataStore,
+		logger:             zap.L(),
 		maxBlocksBehind:    10,
 	}
 
@@ -116,7 +118,7 @@ func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := &SimpleIsStateOrTracePresent{}
+			f := &SimpleIsStateOrTracePresent{logger: zap.L()}
 			ok := f.Apply(tt.args.requestMetadata, tt.args.upstreamConfig)
 			assert.Equalf(t, tt.want, ok, "Apply(%v, %v)", tt.args.requestMetadata, tt.args.upstreamConfig)
 		})

--- a/internal/route/request_executor.go
+++ b/internal/route/request_executor.go
@@ -16,6 +16,7 @@ import (
 
 type RequestExecutor struct {
 	httpClient client.HTTPClient
+	logger     *zap.Logger
 }
 
 type ExecutorResult struct {
@@ -31,13 +32,13 @@ func (r *RequestExecutor) routeToConfig(
 ) (jsonrpc.ResponseBody, *http.Response, error) {
 	bodyBytes, err := requestBody.Encode()
 	if err != nil {
-		zap.L().Error("Could not serialize request.", zap.Any("request", requestBody), zap.Error(err))
+		r.logger.Error("Could not serialize request.", zap.Any("request", requestBody), zap.Error(err))
 		return nil, nil, err
 	}
 
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", configToRoute.HTTPURL, bytes.NewReader(bodyBytes))
 	if err != nil {
-		zap.L().Error("Could not create new http request.", zap.Any("request", requestBody), zap.Error(err))
+		r.logger.Error("Could not create new http request.", zap.Any("request", requestBody), zap.Error(err))
 		return nil, nil, err
 	}
 
@@ -49,18 +50,18 @@ func (r *RequestExecutor) routeToConfig(
 	resp, err := r.httpClient.Do(httpReq)
 
 	if err != nil {
-		zap.L().Error("Error encountered when executing request.", zap.Any("request", requestBody), zap.String("response", fmt.Sprintf("%v", resp)), zap.Error(err))
+		r.logger.Error("Error encountered when executing request.", zap.Any("request", requestBody), zap.String("response", fmt.Sprintf("%v", resp)), zap.Error(err))
 		return nil, nil, err
 	}
 	defer resp.Body.Close()
 
 	respBody, err := jsonrpc.DecodeResponseBody(resp)
 	if err != nil {
-		zap.L().Warn("Could not deserialize response.", zap.Any("request", requestBody), zap.String("response", fmt.Sprintf("%v", resp)), zap.Error(err))
+		r.logger.Warn("Could not deserialize response.", zap.Any("request", requestBody), zap.String("response", fmt.Sprintf("%v", resp)), zap.Error(err))
 		return nil, nil, err
 	}
 
-	zap.L().Debug("Successfully routed request to upstream.", zap.String("upstreamID", configToRoute.ID), zap.Any("request", requestBody), zap.Any("response", respBody))
+	r.logger.Debug("Successfully routed request to upstream.", zap.String("upstreamID", configToRoute.ID), zap.Any("request", requestBody), zap.Any("response", respBody))
 
 	return respBody, resp, nil
 }

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -61,7 +61,7 @@ func NewRouter(
 		upstreamConfigs:     upstreamConfigs,
 		priorityToUpstreams: groupUpstreamsByPriority(upstreamConfigs, groupConfigs),
 		routingStrategy:     routingStrategy,
-		requestExecutor:     RequestExecutor{httpClient: &http.Client{}},
+		requestExecutor:     RequestExecutor{httpClient: &http.Client{}, logger: logger},
 		metadataParser:      metadata.RequestMetadataParser{},
 		metricsContainer:    metricsContainer,
 		logger:              logger,

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -39,6 +39,7 @@ type SimpleRouter struct {
 	routingStrategy    RoutingStrategy
 	requestExecutor    RequestExecutor
 	metricsContainer   *metrics.Container
+	logger             *zap.Logger
 	// Map from Priority => UpstreamIDs
 	priorityToUpstreams types.PriorityToUpstreamsMap
 	metadataParser      metadata.RequestMetadataParser
@@ -52,6 +53,7 @@ func NewRouter(
 	healthCheckManager checks.HealthCheckManager,
 	routingStrategy RoutingStrategy,
 	metricsContainer *metrics.Container,
+	logger *zap.Logger,
 ) Router {
 	r := &SimpleRouter{
 		chainMetadataStore:  chainMetadataStore,
@@ -62,6 +64,7 @@ func NewRouter(
 		requestExecutor:     RequestExecutor{httpClient: &http.Client{}},
 		metadataParser:      metadata.RequestMetadataParser{},
 		metricsContainer:    metricsContainer,
+		logger:              logger,
 	}
 
 	return r
@@ -137,7 +140,7 @@ func (r *SimpleRouter) Route(
 		requestBody.GetMethod(),
 	).Inc()
 
-	zap.L().Debug("Routing request to upstream.", zap.String("upstreamID", id), zap.Any("request", requestBody), zap.String("client", util.GetClientFromContext(ctx)))
+	r.logger.Debug("Routing request to upstream.", zap.String("upstreamID", id), zap.Any("request", requestBody), zap.String("client", util.GetClientFromContext(ctx)))
 
 	go func() {
 		for _, request := range requestBody.GetSubRequests() {

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/metadata"
 	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/types"
+	"go.uber.org/zap"
 
 	"github.com/satsuma-data/node-gateway/internal/config"
 	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
@@ -34,7 +35,7 @@ func TestRouter_NoHealthyUpstreams(t *testing.T) {
 	routingStrategy := mocks.NewMockRoutingStrategy(t)
 	routingStrategy.EXPECT().RouteNextRequest(mock.Anything, mock.Anything).Return("", ErrNoHealthyUpstreams)
 
-	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, routingStrategy, metrics.NewContainer())
+	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, routingStrategy, metrics.NewContainer(), zap.L())
 	router.(*SimpleRouter).healthCheckManager = managerMock
 	router.Start()
 
@@ -107,7 +108,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 			Priority: 2,
 		},
 	}
-	router := NewRouter(upstreamConfigs, groupConfigs, metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer())
+	router := NewRouter(upstreamConfigs, groupConfigs, metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer(), zap.L())
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
@@ -152,7 +153,7 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 		erigonConfig,
 	}
 
-	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer())
+	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer(), zap.L())
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 

--- a/internal/route/routing_strategy.go
+++ b/internal/route/routing_strategy.go
@@ -21,11 +21,13 @@ type RoutingStrategy interface {
 	) (string, error)
 }
 type PriorityRoundRobinStrategy struct {
+	logger  *zap.Logger
 	counter uint64
 }
 
-func NewPriorityRoundRobinStrategy() *PriorityRoundRobinStrategy {
+func NewPriorityRoundRobinStrategy(logger *zap.Logger) *PriorityRoundRobinStrategy {
 	return &PriorityRoundRobinStrategy{
+		logger:  logger,
 		counter: 0,
 	}
 }
@@ -48,7 +50,7 @@ func (s *PriorityRoundRobinStrategy) RouteNextRequest(
 			return upstreams[int(s.counter)%len(upstreams)].ID, nil
 		}
 
-		zap.L().Debug("Did not find any healthy nodes in priority.", zap.Int("priority", priority))
+		s.logger.Debug("Did not find any healthy nodes in priority.", zap.Int("priority", priority))
 	}
 
 	return "", ErrNoHealthyUpstreams

--- a/internal/route/routing_strategy_test.go
+++ b/internal/route/routing_strategy_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/metadata"
 	"github.com/satsuma-data/node-gateway/internal/types"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 func TestPriorityStrategy_HighPriority(t *testing.T) {
@@ -16,7 +17,7 @@ func TestPriorityStrategy_HighPriority(t *testing.T) {
 		1: {cfg("erigon")},
 	}
 
-	strategy := NewPriorityRoundRobinStrategy()
+	strategy := NewPriorityRoundRobinStrategy(zap.L())
 
 	for i := 0; i < 10; i++ {
 		firstUpstreamID, _ := strategy.RouteNextRequest(upstreams, metadata.RequestMetadata{})
@@ -39,7 +40,7 @@ func TestPriorityStrategy_LowerPriority(t *testing.T) {
 		1: {cfg("fallback1"), cfg("fallback2")},
 	}
 
-	strategy := NewPriorityRoundRobinStrategy()
+	strategy := NewPriorityRoundRobinStrategy(zap.L())
 
 	for i := 0; i < 10; i++ {
 		firstUpstreamID, _ := strategy.RouteNextRequest(upstreams, metadata.RequestMetadata{})
@@ -56,7 +57,7 @@ func TestPriorityStrategy_NoUpstreams(t *testing.T) {
 		1: {},
 	}
 
-	strategy := NewPriorityRoundRobinStrategy()
+	strategy := NewPriorityRoundRobinStrategy(zap.L())
 
 	for i := 0; i < 10; i++ {
 		upstreamID, err := strategy.RouteNextRequest(upstreams, metadata.RequestMetadata{})

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestServeHTTP_ForwardsToSoleHealthyUpstream(t *testing.T) {
@@ -256,7 +257,8 @@ func executeRequest(t *testing.T, request jsonrpc.RequestBody, handler *RPCHandl
 }
 
 func startRouterAndHandler(conf config.Config) *RPCHandler {
-	dependencyContainer := wireDependencies(conf)
+	testLogger := zap.L()
+	dependencyContainer := wireDependencies(conf, testLogger)
 	router := dependencyContainer.router
 	router.Start()
 
@@ -266,6 +268,7 @@ func startRouterAndHandler(conf config.Config) *RPCHandler {
 
 	handler := &RPCHandler{
 		router: router,
+		logger: testLogger,
 	}
 
 	return handler

--- a/internal/server/web_server_test.go
+++ b/internal/server/web_server_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 
 	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
 	"github.com/satsuma-data/node-gateway/internal/mocks"
@@ -31,7 +32,7 @@ func TestHandleJSONRPCRequest_Success(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader("dummy")),
 			}, nil)
 
-	handler := &RPCHandler{router: router}
+	handler := &RPCHandler{router: router, logger: zap.L()}
 
 	emptyJSONBody, _ := json.Marshal(map[string]any{})
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(emptyJSONBody))
@@ -87,7 +88,7 @@ func TestHandleJSONRPCRequest_NonJSONContentType(t *testing.T) {
 
 func TestHandleJSONRPCRequest_BadJSON(t *testing.T) {
 	router := mocks.NewRouter(t)
-	handler := &RPCHandler{router: router}
+	handler := &RPCHandler{router: router, logger: zap.L()}
 
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte("{\"bad_json\": ")))
 	req.Header.Add("Content-Type", "application/json")
@@ -104,7 +105,7 @@ func TestHandleJSONRPCRequest_BadJSON(t *testing.T) {
 
 func TestHandleJSONRPCRequest_UnknownBodyField(t *testing.T) {
 	router := mocks.NewRouter(t)
-	handler := &RPCHandler{router: router}
+	handler := &RPCHandler{router: router, logger: zap.L()}
 
 	emptyJSONBody, _ := json.Marshal(map[string]any{"unknown_field": "value"})
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(emptyJSONBody))
@@ -130,7 +131,7 @@ func TestHandleJSONRPCRequest_NilJSONRPCResponse(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader("dummy")),
 			}, nil)
 
-	handler := &RPCHandler{router: router}
+	handler := &RPCHandler{router: router, logger: zap.L()}
 
 	emptyJSONBody, _ := json.Marshal(map[string]any{})
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(emptyJSONBody))
@@ -155,7 +156,7 @@ func TestHandleJSONRPCRequest_JSONRPCDecodeError(t *testing.T) {
 	router.On("Route", mock.Anything, mock.Anything).
 		Return(nil, nil, jsonrpc.DecodeError{Err: errors.New("error decoding"), Content: undecodableContent})
 
-	handler := &RPCHandler{router: router}
+	handler := &RPCHandler{router: router, logger: zap.L()}
 
 	emptyJSONBody, _ := json.Marshal(map[string]any{})
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(emptyJSONBody))


### PR DESCRIPTION
# Description

This PR introduces a `logger` field into all objects that are operating on a single chain level. This enables creating a separate logger for each chain when we add multi-chain support.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

(Testing from a follow-up PR) Confirmed that logs contain a `chainName` field.
