### PR TITLE
feat: support multiple chains in a single process

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -51,14 +51,15 @@ func main() {
 		zap.L().Fatal("Failed to load config.", zap.Error(err))
 	}
 
-	var rpcServer server.RPCServer
+	var rpcServer *server.RPCServer
 
 	var metricsServer *http.Server
 
 	zap.L().Info("Starting node gateway.", zap.String("env", env), zap.Any("config", conf))
 
 	go func() {
-		rpcServer = server.NewRPCServer(conf, logger)
+		dependencyContainer := server.WireDependenciesForAllChains(conf, logger)
+		rpcServer = dependencyContainer.RPCServer
 
 		if err := rpcServer.Start(); err != http.ErrServerClosed {
 			zap.L().Fatal("Failed to start RPC server.", zap.Error(err))

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -58,8 +58,8 @@ func main() {
 	zap.L().Info("Starting node gateway.", zap.String("env", env), zap.Any("config", conf))
 
 	go func() {
-		dependencyContainer := server.WireDependenciesForAllChains(conf, logger)
-		rpcServer = dependencyContainer.RPCServer
+		objectGraph := server.WireDependenciesForAllChains(conf, logger)
+		rpcServer = objectGraph.RPCServer
 
 		if err := rpcServer.Start(); err != http.ErrServerClosed {
 			zap.L().Fatal("Failed to start RPC server.", zap.Error(err))

--- a/configs/config.sample.yml
+++ b/configs/config.sample.yml
@@ -1,61 +1,65 @@
 global:
   port: 8080
 
-routing:
-  # Number of blocks a node can be behind the max known height and
-  # still get requests routed to it.
-  maxBlocksBehind: 10
+# List of supported chains.
+# The HTTP endpoint for a given chain is <host>:<port>/<chainName>.
+chains:
+  - chainName: ethereum
+    routing:
+      # Number of blocks a node can be behind the max known height and
+      # still get requests routed to it.
+      maxBlocksBehind: 10
 
-# (Optional) List of upstream node groups.
-# If defined, all upstreams must define group membership via the `group` field.
-groups:
-  # Each group must have the following keys
-  # 
-  # id - Unique identifer for the group.
-  # priority - Defines the routing priority for nodes in the group.
-  #            The lower the number, the higher the priority. 
-  #            Priority routing works by identifying the highest priority group with at least 
-  #              one healthy upstream. For example, if the highest priority group doesn't have any healthy upstreams, 
-  #              the gateway will look at the group at the next priority level to see if it has any healthy upstreams. It will continue 
-  #              until it finds a group that has at least one healthy upstream. If there are multiple upstreams in that group, requests are
-  #              spread across the upstreams in a round-robin fashion.
-  - id: primary
-    priority: 0
-  - id: fallback
-    priority: 1
-  
-# List of upstream node RPCs.
-upstreams:
-  # Each upstream can have the following keys:
-  #
-  # id - Unique identifier for the upstream.
-  # httpURL - HTTP JSON RPC URL.
-  # wsURL - Websocket URL.
-  # basicAuth - Basic HTTP authentication username and password.
-  # healthCheck - Health check-specific configuration.
-  #   useWsForBlockHeight - Whether or not we subscribe to newHeads using
-  #     websockets to detect the latest block height. This is preferred because
-  #     it quickly updates the gateway with the latest block height. If this
-  #     setting is undefined, the gateway will attempt to subscribe to new
-  #     heads if the upstream supports it.
-  # nodeType - full or archive
-  - id: my-node
-    httpURL: "http://12.57.207.168:8545"
-    wsURL: "wss://12.57.207.168:8546"
-    group: primary
-    nodeType: full
-  - id: infura-eth
-    httpURL: "https://mainnet.infura.io/v3/${INFURA_API_KEY}"
-    wsURL: "wss://mainnet.infura.io/ws/v3/${INFURA_API_KEY}"
-    basicAuth:
-      username: ~
-      password: ${INFURA_API_KEY_SECRET}
-    group: fallback
-    nodeType: archive
-  - id: alchemy-eth
-    httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-    wsURL: "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-    healthCheck:
-      useWsForBlockHeight: false
-    group: fallback
-    nodeType: full
+    # (Optional) List of upstream node groups.
+    # If defined, all upstreams must define group membership via the `group` field.
+    groups:
+      # Each group must have the following keys
+      #
+      # id - Unique identifer for the group.
+      # priority - Defines the routing priority for nodes in the group.
+      #            The lower the number, the higher the priority.
+      #            Priority routing works by identifying the highest priority group with at least
+      #              one healthy upstream. For example, if the highest priority group doesn't have any healthy upstreams,
+      #              the gateway will look at the group at the next priority level to see if it has any healthy upstreams. It will continue
+      #              until it finds a group that has at least one healthy upstream. If there are multiple upstreams in that group, requests are
+      #              spread across the upstreams in a round-robin fashion.
+      - id: primary
+        priority: 0
+      - id: fallback
+        priority: 1
+
+    # List of upstream node RPCs.
+    upstreams:
+      # Each upstream can have the following keys:
+      #
+      # id - Unique identifier for the upstream.
+      # httpURL - HTTP JSON RPC URL.
+      # wsURL - Websocket URL.
+      # basicAuth - Basic HTTP authentication username and password.
+      # healthCheck - Health check-specific configuration.
+      #   useWsForBlockHeight - Whether or not we subscribe to newHeads using
+      #     websockets to detect the latest block height. This is preferred because
+      #     it quickly updates the gateway with the latest block height. If this
+      #     setting is undefined, the gateway will attempt to subscribe to new
+      #     heads if the upstream supports it.
+      # nodeType - full or archive
+      - id: my-node
+        httpURL: "http://12.57.207.168:8545"
+        wsURL: "wss://12.57.207.168:8546"
+        group: primary
+        nodeType: full
+      - id: infura-eth
+        httpURL: "https://mainnet.infura.io/v3/${INFURA_API_KEY}"
+        wsURL: "wss://mainnet.infura.io/ws/v3/${INFURA_API_KEY}"
+        basicAuth:
+          username: ~
+          password: ${INFURA_API_KEY_SECRET}
+        group: fallback
+        nodeType: archive
+      - id: alchemy-eth
+        httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+        wsURL: "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+        healthCheck:
+          useWsForBlockHeight: false
+        group: fallback
+        nodeType: full

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/ethereum/go-ethereum v1.10.21
+	github.com/google/go-cmp v0.5.8
 	github.com/prometheus/client_golang v1.13.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/zap v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,7 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/internal/checks/blockheight_test.go
+++ b/internal/checks/blockheight_test.go
@@ -38,7 +38,7 @@ func TestBlockHeightChecker_WS(t *testing.T) {
 	chainMetadataStore := metadata.NewChainMetadataStore()
 	chainMetadataStore.Start()
 
-	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer("test_net"), zap.L())
+	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer(config.TestChainName), zap.L())
 
 	ethClient.AssertNumberOfCalls(t, "SubscribeNewHead", 1)
 
@@ -66,7 +66,7 @@ func TestBlockHeightChecker_WSSubscribeFailed(t *testing.T) {
 	chainMetadataStore := metadata.NewChainMetadataStore()
 	chainMetadataStore.Start()
 
-	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer("test_net"), zap.L())
+	checker := NewBlockHeightChecker(defaultUpstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer(config.TestChainName), zap.L())
 
 	ethClient.AssertNumberOfCalls(t, "SubscribeNewHead", 1)
 	assert.False(t, checker.IsPassing(maxBlockHeight))
@@ -77,7 +77,7 @@ func TestBlockHeightChecker_WSSubscribeFailed(t *testing.T) {
 }
 
 func TestBlockHeightChecker_HTTP(t *testing.T) {
-	for _, config := range []*config.UpstreamConfig{
+	for _, upstreamConfig := range []*config.UpstreamConfig{
 		{
 			ID:      "eth_mainnet",
 			HTTPURL: "http://alchemy",
@@ -101,7 +101,7 @@ func TestBlockHeightChecker_HTTP(t *testing.T) {
 		chainMetadataStore := metadata.NewChainMetadataStore()
 		chainMetadataStore.Start()
 
-		checker := NewBlockHeightChecker(config, mockEthClientGetter, chainMetadataStore, metrics.NewContainer("test_net"), zap.L())
+		checker := NewBlockHeightChecker(upstreamConfig, mockEthClientGetter, chainMetadataStore, metrics.NewContainer(config.TestChainName), zap.L())
 
 		checker.RunCheck()
 		ethClient.AssertNumberOfCalls(t, "SubscribeNewHead", 0)

--- a/internal/checks/manager_test.go
+++ b/internal/checks/manager_test.go
@@ -40,7 +40,7 @@ func TestHealthCheckManager(t *testing.T) {
 	tickerChan := make(chan time.Time)
 	ticker := &time.Ticker{C: tickerChan}
 
-	metricsContainer := metrics.NewContainer("test_net")
+	metricsContainer := metrics.NewContainer(config.TestChainName)
 
 	manager := NewHealthCheckManager(mockEthClientGetter, configs, nil, ticker, metricsContainer, zap.L())
 	manager.(*healthCheckManager).newBlockHeightCheck = func(

--- a/internal/checks/peers_test.go
+++ b/internal/checks/peers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/satsuma-data/node-gateway/internal/client"
+	"github.com/satsuma-data/node-gateway/internal/config"
 	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/mocks"
 	"github.com/stretchr/testify/assert"
@@ -20,7 +21,7 @@ func TestPeerChecker(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer("test_net"), zap.L())
+	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer(config.TestChainName), zap.L())
 
 	assert.True(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "PeerCount", 1)
@@ -55,7 +56,7 @@ func TestPeerChecker_MethodNotSupported(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer("test_net"), zap.L())
+	checker := NewPeerChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer(config.TestChainName), zap.L())
 
 	assert.True(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "PeerCount", 1)

--- a/internal/checks/syncing_test.go
+++ b/internal/checks/syncing_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/satsuma-data/node-gateway/internal/client"
+	"github.com/satsuma-data/node-gateway/internal/config"
 	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/mocks"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func TestSyncingChecker(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer("test_net"), zap.L())
+	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer(config.TestChainName), zap.L())
 
 	assert.False(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "SyncProgress", 1)
@@ -49,7 +50,7 @@ func TestSyncingChecker_MethodNotSupported(t *testing.T) {
 		return ethClient, nil
 	}
 
-	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer("test_net"), zap.L())
+	checker := NewSyncingChecker(defaultUpstreamConfig, mockEthClientGetter, metrics.NewContainer(config.TestChainName), zap.L())
 
 	assert.True(t, checker.IsPassing())
 	ethClient.AssertNumberOfCalls(t, "SyncProgress", 1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,15 @@ type Config struct {
 	Chains []SingleChainConfig
 }
 
+func (config *Config) Validate() error {
+	isValid := isChainsValid(config.Chains)
+
+	if !isValid {
+		return errors.New("invalid config found")
+	}
+	return nil
+}
+
 func LoadConfig(configFilePath string) (Config, error) {
 	configBytes, err := os.ReadFile(configFilePath)
 
@@ -175,11 +184,7 @@ func parseConfig(configBytes []byte) (Config, error) {
 		return config, err
 	}
 
-	isValid := isChainsValid(config.Chains)
-
-	if !isValid {
-		err = errors.New("invalid config found")
-	}
+	err = config.Validate()
 
 	return config, err
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,7 @@ func (c *SingleChainConfig) isValid() bool {
 
 	if c.ChainName == "" {
 		zap.L().Error("chainName cannot be empty", zap.Any("config", c))
+
 		isChainConfigValid = false
 	}
 
@@ -149,12 +150,13 @@ func isChainsValid(chainsConfig []SingleChainConfig) bool {
 
 		isValid = isValid && chainConfig.isValid()
 	}
+
 	return isValid
 }
 
 type Config struct {
-	Global GlobalConfig
 	Chains []SingleChainConfig
+	Global GlobalConfig
 }
 
 func (config *Config) Validate() error {
@@ -163,6 +165,7 @@ func (config *Config) Validate() error {
 	if !isValid {
 		return errors.New("invalid config found")
 	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,9 +1,9 @@
 package config
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -139,6 +139,12 @@ func TestParseConfig_ValidConfig(t *testing.T) {
             wsURL: "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}"
             group: fallback
             nodeType: archive
+
+      - chainName: polygon
+        upstreams:
+          - id: erigon-polygon-1
+            httpURL: "http://127.0.0.1:4040"
+            nodeType: archive
   `
 	configBytes := []byte(config)
 
@@ -186,11 +192,18 @@ func TestParseConfig_ValidConfig(t *testing.T) {
 					Priority: 1,
 				},
 			},
+		}, {
+			ChainName: "polygon",
+			Upstreams: []UpstreamConfig{{
+				ID:       "erigon-polygon-1",
+				HTTPURL:  "http://127.0.0.1:4040",
+				NodeType: Archive,
+			}},
 		}},
 	}
 
-	if !reflect.DeepEqual(parsedConfig, expectedConfig) {
-		t.Errorf("ParseConfig returned unexpected config: %v.", parsedConfig)
+	if diff := cmp.Diff(expectedConfig, parsedConfig); diff != "" {
+		t.Errorf("ParseConfig returned unexpected config - diff:\n%s", diff)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -18,11 +18,13 @@ func TestParseConfig_InvalidConfigs(t *testing.T) {
             global:
               port: 8080
 
-            upstreams:
-              - id: alchemy-eth
-                wsURL: "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-                healthCheck:
-                  useWsForBlockHeight: true
+            chains:
+              - chainName: ethereum
+                upstreams:
+                  - id: alchemy-eth
+                    wsURL: "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+                    healthCheck:
+                      useWsForBlockHeight: true
             `,
 		},
 		{
@@ -31,11 +33,13 @@ func TestParseConfig_InvalidConfigs(t *testing.T) {
             global:
               port: 8080
 
-            upstreams:
-              - id: alchemy-eth
-                httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-                healthCheck:
-                  useWsForBlockHeight: true
+            chains:
+              - chainName: ethereum
+                upstreams:
+                  - id: alchemy-eth
+                    httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+                    healthCheck:
+                      useWsForBlockHeight: true
             `,
 		},
 		{
@@ -44,16 +48,18 @@ func TestParseConfig_InvalidConfigs(t *testing.T) {
             global:
               port: 8080
 
-            upstreams:
-              - id: alchemy-eth
-                httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-                group: primary
-            
-            groups:
-              - id: primary
-                priority: 0
-              - id: fallback
-                priority: 0
+            chains:
+              - chainName: ethereum
+                upstreams:
+                  - id: alchemy-eth
+                    httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+                    group: primary
+                
+                groups:
+                  - id: primary
+                    priority: 0
+                  - id: fallback
+                    priority: 0
             `,
 		},
 		{
@@ -62,13 +68,15 @@ func TestParseConfig_InvalidConfigs(t *testing.T) {
             global:
               port: 8080
 
-            upstreams:
-              - id: alchemy-eth
-                httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-            
-            groups:
-              - id: primary
-                priority: 0
+            chains:
+              - chainName: ethereum
+                upstreams:
+                  - id: alchemy-eth
+                    httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+                
+                groups:
+                  - id: primary
+                    priority: 0
             `,
 		},
 		{
@@ -77,14 +85,16 @@ func TestParseConfig_InvalidConfigs(t *testing.T) {
             global:
               port: 8080
 
-            upstreams:
-              - id: alchemy-eth
-                httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-                group: something-that-doesnt-exist
-            
-            groups:
-              - id: primary
-                priority: 0
+            chains:
+              - chainName: ethereum
+                upstreams:
+                  - id: alchemy-eth
+                    httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+                    group: something-that-doesnt-exist
+                
+                groups:
+                  - id: primary
+                    priority: 0
             `,
 		},
 	} {
@@ -107,27 +117,28 @@ func TestParseConfig_ValidConfig(t *testing.T) {
     global:
       port: 8080
 
-    chainName: ethereum
+    chains:
+      - chainName: ethereum
 
-    groups:
-      - id: primary
-        priority: 0
-      - id: fallback
-        priority: 1
+        groups:
+          - id: primary
+            priority: 0
+          - id: fallback
+            priority: 1
 
-    upstreams:
-      - id: alchemy-eth
-        httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-        wsURL: "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
-        healthCheck:
-          useWsForBlockHeight: true
-        group: primary
-        nodeType: full
-      - id: ankr-polygon
-        httpURL: "https://rpc.ankr.com/polygon"
-        wsURL: "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}"
-        group: fallback
-        nodeType: archive
+        upstreams:
+          - id: alchemy-eth
+            httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+            wsURL: "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+            healthCheck:
+              useWsForBlockHeight: true
+            group: primary
+            nodeType: full
+          - id: ankr-polygon
+            httpURL: "https://rpc.ankr.com/polygon"
+            wsURL: "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}"
+            group: fallback
+            nodeType: archive
   `
 	configBytes := []byte(config)
 
@@ -138,42 +149,44 @@ func TestParseConfig_ValidConfig(t *testing.T) {
 	}
 
 	expectedConfig := Config{
-		Upstreams: []UpstreamConfig{
-			{
-				ID:      "alchemy-eth",
-				HTTPURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
-				WSURL:   "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
-				HealthCheckConfig: HealthCheckConfig{
-					UseWSForBlockHeight: newBool(true),
-				},
-				GroupID:  "primary",
-				NodeType: Full,
-			},
-			{
-				ID:      "ankr-polygon",
-				HTTPURL: "https://rpc.ankr.com/polygon",
-				WSURL:   "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}",
-				HealthCheckConfig: HealthCheckConfig{
-					UseWSForBlockHeight: nil,
-				},
-				GroupID:  "fallback",
-				NodeType: Archive,
-			},
-		},
 		Global: GlobalConfig{
 			Port: 8080,
 		},
-		ChainName: "ethereum",
-		Groups: []GroupConfig{
-			{
-				ID:       "primary",
-				Priority: 0,
+		Chains: []SingleChainConfig{{
+			Upstreams: []UpstreamConfig{
+				{
+					ID:      "alchemy-eth",
+					HTTPURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
+					WSURL:   "wss://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
+					HealthCheckConfig: HealthCheckConfig{
+						UseWSForBlockHeight: newBool(true),
+					},
+					GroupID:  "primary",
+					NodeType: Full,
+				},
+				{
+					ID:      "ankr-polygon",
+					HTTPURL: "https://rpc.ankr.com/polygon",
+					WSURL:   "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}",
+					HealthCheckConfig: HealthCheckConfig{
+						UseWSForBlockHeight: nil,
+					},
+					GroupID:  "fallback",
+					NodeType: Archive,
+				},
 			},
-			{
-				ID:       "fallback",
-				Priority: 1,
+			ChainName: "ethereum",
+			Groups: []GroupConfig{
+				{
+					ID:       "primary",
+					Priority: 0,
+				},
+				{
+					ID:       "fallback",
+					Priority: 1,
+				},
 			},
-		},
+		}},
 	}
 
 	if !reflect.DeepEqual(parsedConfig, expectedConfig) {

--- a/internal/config/config_test_data.go
+++ b/internal/config/config_test_data.go
@@ -1,0 +1,3 @@
+package config
+
+const TestChainName = "test_net"

--- a/internal/mocks/EthClient.go
+++ b/internal/mocks/EthClient.go
@@ -56,8 +56,8 @@ type EthClient_HeaderByNumber_Call struct {
 }
 
 // HeaderByNumber is a helper method to define mock.On call
-//   - ctx context.Context
-//   - number *big.Int
+//  - ctx context.Context
+//  - number *big.Int
 func (_e *EthClient_Expecter) HeaderByNumber(ctx interface{}, number interface{}) *EthClient_HeaderByNumber_Call {
 	return &EthClient_HeaderByNumber_Call{Call: _e.mock.On("HeaderByNumber", ctx, number)}
 }
@@ -101,7 +101,7 @@ type EthClient_PeerCount_Call struct {
 }
 
 // PeerCount is a helper method to define mock.On call
-//   - ctx context.Context
+//  - ctx context.Context
 func (_e *EthClient_Expecter) PeerCount(ctx interface{}) *EthClient_PeerCount_Call {
 	return &EthClient_PeerCount_Call{Call: _e.mock.On("PeerCount", ctx)}
 }
@@ -147,8 +147,8 @@ type EthClient_SubscribeNewHead_Call struct {
 }
 
 // SubscribeNewHead is a helper method to define mock.On call
-//   - ctx context.Context
-//   - ch chan<- *types.Header
+//  - ctx context.Context
+//  - ch chan<- *types.Header
 func (_e *EthClient_Expecter) SubscribeNewHead(ctx interface{}, ch interface{}) *EthClient_SubscribeNewHead_Call {
 	return &EthClient_SubscribeNewHead_Call{Call: _e.mock.On("SubscribeNewHead", ctx, ch)}
 }
@@ -194,7 +194,7 @@ type EthClient_SyncProgress_Call struct {
 }
 
 // SyncProgress is a helper method to define mock.On call
-//   - ctx context.Context
+//  - ctx context.Context
 func (_e *EthClient_Expecter) SyncProgress(ctx interface{}) *EthClient_SyncProgress_Call {
 	return &EthClient_SyncProgress_Call{Call: _e.mock.On("SyncProgress", ctx)}
 }

--- a/internal/mocks/Router.go
+++ b/internal/mocks/Router.go
@@ -15,6 +15,14 @@ type Router struct {
 	mock.Mock
 }
 
+type Router_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *Router) EXPECT() *Router_Expecter {
+	return &Router_Expecter{mock: &_m.Mock}
+}
+
 // IsInitialized provides a mock function with given fields:
 func (_m *Router) IsInitialized() bool {
 	ret := _m.Called()
@@ -29,41 +37,116 @@ func (_m *Router) IsInitialized() bool {
 	return r0
 }
 
+// Router_IsInitialized_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsInitialized'
+type Router_IsInitialized_Call struct {
+	*mock.Call
+}
+
+// IsInitialized is a helper method to define mock.On call
+func (_e *Router_Expecter) IsInitialized() *Router_IsInitialized_Call {
+	return &Router_IsInitialized_Call{Call: _e.mock.On("IsInitialized")}
+}
+
+func (_c *Router_IsInitialized_Call) Run(run func()) *Router_IsInitialized_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Router_IsInitialized_Call) Return(_a0 bool) *Router_IsInitialized_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
 // Route provides a mock function with given fields: ctx, requestBody
-func (_m *Router) Route(ctx context.Context, requestBody jsonrpc.RequestBody) (jsonrpc.ResponseBody, *http.Response, error) {
+func (_m *Router) Route(ctx context.Context, requestBody jsonrpc.RequestBody) (string, jsonrpc.ResponseBody, *http.Response, error) {
 	ret := _m.Called(ctx, requestBody)
 
-	var r0 jsonrpc.ResponseBody
-	if rf, ok := ret.Get(0).(func(context.Context, jsonrpc.RequestBody) jsonrpc.ResponseBody); ok {
+	var r0 string
+	if rf, ok := ret.Get(0).(func(context.Context, jsonrpc.RequestBody) string); ok {
 		r0 = rf(ctx, requestBody)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(jsonrpc.ResponseBody)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
-	var r1 *http.Response
-	if rf, ok := ret.Get(1).(func(context.Context, jsonrpc.RequestBody) *http.Response); ok {
+	var r1 jsonrpc.ResponseBody
+	if rf, ok := ret.Get(1).(func(context.Context, jsonrpc.RequestBody) jsonrpc.ResponseBody); ok {
 		r1 = rf(ctx, requestBody)
 	} else {
 		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*http.Response)
+			r1 = ret.Get(1).(jsonrpc.ResponseBody)
 		}
 	}
 
-	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, jsonrpc.RequestBody) error); ok {
+	var r2 *http.Response
+	if rf, ok := ret.Get(2).(func(context.Context, jsonrpc.RequestBody) *http.Response); ok {
 		r2 = rf(ctx, requestBody)
 	} else {
-		r2 = ret.Error(2)
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).(*http.Response)
+		}
 	}
 
-	return r0, r1, r2
+	var r3 error
+	if rf, ok := ret.Get(3).(func(context.Context, jsonrpc.RequestBody) error); ok {
+		r3 = rf(ctx, requestBody)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
+}
+
+// Router_Route_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Route'
+type Router_Route_Call struct {
+	*mock.Call
+}
+
+// Route is a helper method to define mock.On call
+//  - ctx context.Context
+//  - requestBody jsonrpc.RequestBody
+func (_e *Router_Expecter) Route(ctx interface{}, requestBody interface{}) *Router_Route_Call {
+	return &Router_Route_Call{Call: _e.mock.On("Route", ctx, requestBody)}
+}
+
+func (_c *Router_Route_Call) Run(run func(ctx context.Context, requestBody jsonrpc.RequestBody)) *Router_Route_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(jsonrpc.RequestBody))
+	})
+	return _c
+}
+
+func (_c *Router_Route_Call) Return(_a0 string, _a1 jsonrpc.ResponseBody, _a2 *http.Response, _a3 error) *Router_Route_Call {
+	_c.Call.Return(_a0, _a1, _a2, _a3)
+	return _c
 }
 
 // Start provides a mock function with given fields:
 func (_m *Router) Start() {
 	_m.Called()
+}
+
+// Router_Start_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Start'
+type Router_Start_Call struct {
+	*mock.Call
+}
+
+// Start is a helper method to define mock.On call
+func (_e *Router_Expecter) Start() *Router_Start_Call {
+	return &Router_Start_Call{Call: _e.mock.On("Start")}
+}
+
+func (_c *Router_Start_Call) Run(run func()) *Router_Start_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Router_Start_Call) Return() *Router_Start_Call {
+	_c.Call.Return()
+	return _c
 }
 
 type mockConstructorTestingTNewRouter interface {

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -208,3 +208,23 @@ func (r *SimpleRouter) Route(
 
 	return upstreamID, body, response, err
 }
+
+type RouterCollection struct {
+	Routers []Router
+}
+
+func (r *RouterCollection) Start() {
+	for _, router := range r.Routers {
+		router.Start()
+	}
+}
+
+func (r *RouterCollection) IsInitialized() bool {
+	for _, router := range r.Routers {
+		if !router.IsInitialized() {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -26,11 +26,11 @@ import (
 // For now this is pretty simple, but in the future we'll have things like
 // caching, rate limiting, API-based routing and more.
 
-//go:generate mockery --output ../mocks --name Router
+//go:generate mockery --output ../mocks --name Router --with-expecter
 type Router interface {
 	Start()
 	IsInitialized() bool
-	Route(ctx context.Context, requestBody jsonrpc.RequestBody) (jsonrpc.ResponseBody, *http.Response, error)
+	Route(ctx context.Context, requestBody jsonrpc.RequestBody) (string, jsonrpc.ResponseBody, *http.Response, error)
 }
 
 type SimpleRouter struct {
@@ -107,9 +107,9 @@ func (r *SimpleRouter) IsInitialized() bool {
 func (r *SimpleRouter) Route(
 	ctx context.Context,
 	requestBody jsonrpc.RequestBody,
-) (jsonrpc.ResponseBody, *http.Response, error) {
+) (string, jsonrpc.ResponseBody, *http.Response, error) {
 	requestMetadata := r.metadataParser.Parse(requestBody)
-	id, err := r.routingStrategy.RouteNextRequest(r.priorityToUpstreams, requestMetadata)
+	upstreamID, err := r.routingStrategy.RouteNextRequest(r.priorityToUpstreams, requestMetadata)
 
 	if err != nil {
 		switch {
@@ -119,34 +119,38 @@ func (r *SimpleRouter) Route(
 				Body:       io.NopCloser(bytes.NewBufferString(err.Error())),
 			}
 
-			return nil, httpResp, nil
+			return "", nil, httpResp, nil
 		default:
-			return nil, nil, err
+			return "", nil, nil, err
 		}
 	}
 
 	var configToRoute config.UpstreamConfig
 
 	for _, upstreamConfig := range r.upstreamConfigs {
-		if upstreamConfig.ID == id {
+		if upstreamConfig.ID == upstreamID {
 			configToRoute = upstreamConfig
 		}
 	}
 
+	requestPath, ok := ctx.Value("path").(string)
+	if !ok {
+		requestPath = "<unknown>"
+	}
+
+	r.logger.Debug("Routing request to upstream.", zap.String("upstreamID", upstreamID), zap.Any("request", requestBody), zap.String("client", util.GetClientFromContext(ctx)), zap.String("requestPath", requestPath))
 	r.metricsContainer.UpstreamRPCRequestsTotal.WithLabelValues(
 		util.GetClientFromContext(ctx),
-		id,
+		upstreamID,
 		configToRoute.HTTPURL,
 		requestBody.GetMethod(),
 	).Inc()
-
-	r.logger.Debug("Routing request to upstream.", zap.String("upstreamID", id), zap.Any("request", requestBody), zap.String("client", util.GetClientFromContext(ctx)))
 
 	go func() {
 		for _, request := range requestBody.GetSubRequests() {
 			r.metricsContainer.UpstreamJSONRPCRequestsTotal.WithLabelValues(
 				util.GetClientFromContext(ctx),
-				id,
+				upstreamID,
 				configToRoute.HTTPURL,
 				request.Method,
 			).Inc()
@@ -164,7 +168,7 @@ func (r *SimpleRouter) Route(
 	if err != nil {
 		r.metricsContainer.UpstreamRPCRequestErrorsTotal.WithLabelValues(
 			util.GetClientFromContext(ctx),
-			id,
+			upstreamID,
 			configToRoute.HTTPURL,
 			requestBody.GetMethod(),
 			HTTPReponseCode,
@@ -184,11 +188,11 @@ func (r *SimpleRouter) Route(
 			if resp.Error != nil {
 				zap.L().Warn("Encountered error in upstream JSONRPC response.",
 					zap.Any("request", requestBody), zap.Any("error", resp.Error),
-					zap.String("client", util.GetClientFromContext(ctx)), zap.String("upstreamID", id))
+					zap.String("client", util.GetClientFromContext(ctx)), zap.String("upstreamID", upstreamID))
 
 				r.metricsContainer.UpstreamJSONRPCRequestErrorsTotal.WithLabelValues(
 					util.GetClientFromContext(ctx),
-					id,
+					upstreamID,
 					configToRoute.HTTPURL,
 					reqIDToRequestMap[resp.ID].Method,
 					HTTPReponseCode,
@@ -207,5 +211,5 @@ func (r *SimpleRouter) Route(
 		"",
 	).Observe(time.Since(start).Seconds())
 
-	return body, response, err
+	return upstreamID, body, response, err
 }

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -208,23 +208,3 @@ func (r *SimpleRouter) Route(
 
 	return upstreamID, body, response, err
 }
-
-type RouterCollection struct {
-	Routers []Router
-}
-
-func (r *RouterCollection) Start() {
-	for _, router := range r.Routers {
-		router.Start()
-	}
-}
-
-func (r *RouterCollection) IsInitialized() bool {
-	for _, router := range r.Routers {
-		if !router.IsInitialized() {
-			return false
-		}
-	}
-
-	return true
-}

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -133,12 +133,7 @@ func (r *SimpleRouter) Route(
 		}
 	}
 
-	requestPath, ok := ctx.Value("path").(string)
-	if !ok {
-		requestPath = "<unknown>"
-	}
-
-	r.logger.Debug("Routing request to upstream.", zap.String("upstreamID", upstreamID), zap.Any("request", requestBody), zap.String("client", util.GetClientFromContext(ctx)), zap.String("requestPath", requestPath))
+	r.logger.Debug("Routing request to upstream.", zap.String("upstreamID", upstreamID), zap.Any("request", requestBody), zap.String("client", util.GetClientFromContext(ctx)))
 	r.metricsContainer.UpstreamRPCRequestsTotal.WithLabelValues(
 		util.GetClientFromContext(ctx),
 		upstreamID,

--- a/internal/route/router_collection.go
+++ b/internal/route/router_collection.go
@@ -1,0 +1,21 @@
+package route
+
+type RouterCollection struct {
+	Routers []Router
+}
+
+func (r *RouterCollection) Start() {
+	for _, router := range r.Routers {
+		router.Start()
+	}
+}
+
+func (r *RouterCollection) IsInitialized() bool {
+	for _, router := range r.Routers {
+		if !router.IsInitialized() {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -35,7 +35,7 @@ func TestRouter_NoHealthyUpstreams(t *testing.T) {
 	routingStrategy := mocks.NewMockRoutingStrategy(t)
 	routingStrategy.EXPECT().RouteNextRequest(mock.Anything, mock.Anything).Return("", ErrNoHealthyUpstreams)
 
-	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, routingStrategy, metrics.NewContainer("test_net"), zap.L())
+	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, routingStrategy, metrics.NewContainer(config.TestChainName), zap.L())
 	router.(*SimpleRouter).healthCheckManager = managerMock
 	router.Start()
 
@@ -108,7 +108,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 			Priority: 2,
 		},
 	}
-	router := NewRouter(upstreamConfigs, groupConfigs, metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer("test_net"), zap.L())
+	router := NewRouter(upstreamConfigs, groupConfigs, metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer(config.TestChainName), zap.L())
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
@@ -153,7 +153,7 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 		erigonConfig,
 	}
 
-	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer("test_net"), zap.L())
+	router := NewRouter(upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer(config.TestChainName), zap.L())
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -39,7 +39,7 @@ func TestRouter_NoHealthyUpstreams(t *testing.T) {
 	router.(*SimpleRouter).healthCheckManager = managerMock
 	router.Start()
 
-	jsonResp, httpResp, err := router.Route(context.Background(), &jsonrpc.BatchRequestBody{})
+	_, jsonResp, httpResp, err := router.Route(context.Background(), &jsonrpc.BatchRequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, jsonResp)
@@ -112,10 +112,11 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
+	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)
+	assert.Equal(t, erigonConfig.ID, upstreamID)
 	assert.Equal(t, 203, httpResp.StatusCode)
 	assert.Equal(t, "hello", jsonRPCResp.(*jsonrpc.SingleResponseBody).Result)
 	routingStrategyMock.AssertCalled(t, "RouteNextRequest", types.PriorityToUpstreamsMap{
@@ -157,10 +158,11 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
+	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)
+	assert.Equal(t, erigonConfig.ID, upstreamID)
 	assert.Equal(t, 203, httpResp.StatusCode)
 	assert.Equal(t, "hello", jsonRPCResp.(*jsonrpc.SingleResponseBody).Result)
 	routingStrategyMock.AssertCalled(t, "RouteNextRequest", types.PriorityToUpstreamsMap{

--- a/internal/server/health_check_handler.go
+++ b/internal/server/health_check_handler.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/satsuma-data/node-gateway/internal/route"
+	"go.uber.org/zap"
+)
+
+type HealthCheckHandler struct {
+	logger           *zap.Logger
+	routerCollection route.RouterCollection
+}
+
+func (h *HealthCheckHandler) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
+	if h.routerCollection.IsInitialized() {
+		respondRaw(h.logger, writer, []byte("OK"), http.StatusOK)
+	} else {
+		respondRaw(h.logger, writer, []byte("Starting up"), http.StatusServiceUnavailable)
+	}
+}

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -22,7 +22,7 @@ type SingleChainObjectGraph struct {
 func wireDependenciesForAllChains(
 	config config.Config,
 	rootLogger *zap.Logger,
-) DependencyContainer {
+) ObjectGraph {
 	var singleChainDependencies []SingleChainObjectGraph
 	for chainIndex := range config.Chains {
 		currentChainConfig := &config.Chains[chainIndex]
@@ -44,15 +44,15 @@ func wireDependenciesForAllChains(
 		mux.Handle(container.handler.path, container.handler)
 	}
 
-	return DependencyContainer{
-		singleChainDependencies: singleChainDependencies,
-		handler:                 mux,
+	return ObjectGraph{
+		singleChainGraphs: singleChainDependencies,
+		handler:           mux,
 	}
 }
 
-type DependencyContainer struct {
-	singleChainDependencies []SingleChainObjectGraph
-	handler                 *http.ServeMux
+type ObjectGraph struct {
+	singleChainGraphs []SingleChainObjectGraph
+	handler           *http.ServeMux
 }
 
 func wireSingleChainDependencies(config *config.SingleChainConfig, logger *zap.Logger) SingleChainObjectGraph {

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/satsuma-data/node-gateway/internal/checks"
+	"github.com/satsuma-data/node-gateway/internal/client"
+	"github.com/satsuma-data/node-gateway/internal/config"
+	"github.com/satsuma-data/node-gateway/internal/metadata"
+	"github.com/satsuma-data/node-gateway/internal/metrics"
+	"github.com/satsuma-data/node-gateway/internal/route"
+	"go.uber.org/zap"
+)
+
+type SingleChainDependencyContainer struct {
+	ChainName string
+	Router    route.Router
+	handler   *RPCHandler
+}
+
+func wireDependenciesForAllChains(
+	config config.Config,
+	rootLogger *zap.Logger,
+) DependencyContainer {
+	var singleChainDependencies []SingleChainDependencyContainer
+	for chainIndex := range config.Chains {
+		currentChainConfig := &config.Chains[chainIndex]
+		childLogger := rootLogger.With(zap.String("chainName", currentChainConfig.ChainName))
+
+		dependencyContainer := wireSingleChainDependencies(currentChainConfig, childLogger)
+		singleChainDependencies = append(singleChainDependencies, dependencyContainer)
+	}
+
+	healthCheckHandler := &HealthCheckHandler{
+		singleChainDependencies: singleChainDependencies,
+		logger:                  rootLogger,
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/health", healthCheckHandler)
+
+	for _, container := range singleChainDependencies {
+		mux.Handle(container.handler.path, container.handler)
+	}
+
+	return DependencyContainer{
+		singleChainDependencies: singleChainDependencies,
+		handler:                 mux,
+	}
+}
+
+type DependencyContainer struct {
+	singleChainDependencies []SingleChainDependencyContainer
+	handler                 *http.ServeMux
+}
+
+func wireSingleChainDependencies(config *config.SingleChainConfig, logger *zap.Logger) SingleChainDependencyContainer {
+	metricContainer := metrics.NewContainer(config.ChainName)
+	chainMetadataStore := metadata.NewChainMetadataStore()
+	ticker := time.NewTicker(checks.PeriodicHealthCheckInterval)
+	healthCheckManager := checks.NewHealthCheckManager(client.NewEthClient, config.Upstreams, chainMetadataStore, ticker, metricContainer, logger)
+
+	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.SimpleStateOrTracePresent, route.NearGlobalMaxHeight}
+	nodeFilter := route.CreateNodeFilter(enabledNodeFilters, healthCheckManager, chainMetadataStore, logger, &config.Routing)
+	routingStrategy := route.FilteringRoutingStrategy{
+		NodeFilter:      nodeFilter,
+		BackingStrategy: route.NewPriorityRoundRobinStrategy(logger),
+		Logger:          logger,
+	}
+
+	router := route.NewRouter(config.Upstreams, config.Groups, chainMetadataStore, healthCheckManager, &routingStrategy, metricContainer, logger)
+
+	handler := &RPCHandler{
+		path:   "/" + config.ChainName,
+		router: router,
+		logger: logger,
+	}
+
+	return SingleChainDependencyContainer{
+		ChainName: config.ChainName,
+		Router:    router,
+		handler:   handler,
+	}
+}

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -13,9 +13,14 @@ import (
 	"go.uber.org/zap"
 )
 
+type objectGraph struct {
+	singleChainGraphs []singleChainObjectGraph
+	handler           *http.ServeMux
+}
+
 type singleChainObjectGraph struct {
-	ChainName string
-	Router    route.Router
+	chainName string
+	router    route.Router
 	handler   *RPCHandler
 }
 
@@ -42,8 +47,8 @@ func wireSingleChainDependencies(config *config.SingleChainConfig, logger *zap.L
 	}
 
 	return singleChainObjectGraph{
-		ChainName: config.ChainName,
-		Router:    router,
+		chainName: config.ChainName,
+		router:    router,
 		handler:   handler,
 	}
 }
@@ -71,16 +76,11 @@ func wireDependenciesForAllChains(
 
 	for _, container := range singleChainDependencies {
 		mux.Handle(container.handler.path, container.handler)
-		rootLogger.Info("Registered handler for chain.", zap.String("Path", container.handler.path), zap.String("ChainName", container.ChainName))
+		rootLogger.Info("Registered handler for chain.", zap.String("Path", container.handler.path), zap.String("chainName", container.chainName))
 	}
 
 	return objectGraph{
 		singleChainGraphs: singleChainDependencies,
 		handler:           mux,
 	}
-}
-
-type objectGraph struct {
-	singleChainGraphs []singleChainObjectGraph
-	handler           *http.ServeMux
 }

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -57,7 +57,7 @@ func wireDependenciesForAllChains(
 	gatewayConfig config.Config,
 	rootLogger *zap.Logger,
 ) objectGraph {
-	singleChainDependencies := make([]singleChainObjectGraph, len(gatewayConfig.Chains))
+	singleChainDependencies := make([]singleChainObjectGraph, 0, len(gatewayConfig.Chains))
 
 	for chainIndex := range gatewayConfig.Chains {
 		currentChainConfig := &gatewayConfig.Chains[chainIndex]

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -71,6 +71,7 @@ func wireDependenciesForAllChains(
 
 	for _, container := range singleChainDependencies {
 		mux.Handle(container.handler.path, container.handler)
+		rootLogger.Info("Registered handler for chain.", zap.String("Path", container.handler.path), zap.String("ChainName", container.ChainName))
 	}
 
 	return objectGraph{

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -13,7 +13,7 @@ import (
 	"go.uber.org/zap"
 )
 
-type SingleChainDependencyContainer struct {
+type SingleChainObjectGraph struct {
 	ChainName string
 	Router    route.Router
 	handler   *RPCHandler
@@ -23,7 +23,7 @@ func wireDependenciesForAllChains(
 	config config.Config,
 	rootLogger *zap.Logger,
 ) DependencyContainer {
-	var singleChainDependencies []SingleChainDependencyContainer
+	var singleChainDependencies []SingleChainObjectGraph
 	for chainIndex := range config.Chains {
 		currentChainConfig := &config.Chains[chainIndex]
 		childLogger := rootLogger.With(zap.String("chainName", currentChainConfig.ChainName))
@@ -51,11 +51,11 @@ func wireDependenciesForAllChains(
 }
 
 type DependencyContainer struct {
-	singleChainDependencies []SingleChainDependencyContainer
+	singleChainDependencies []SingleChainObjectGraph
 	handler                 *http.ServeMux
 }
 
-func wireSingleChainDependencies(config *config.SingleChainConfig, logger *zap.Logger) SingleChainDependencyContainer {
+func wireSingleChainDependencies(config *config.SingleChainConfig, logger *zap.Logger) SingleChainObjectGraph {
 	metricContainer := metrics.NewContainer(config.ChainName)
 	chainMetadataStore := metadata.NewChainMetadataStore()
 	ticker := time.NewTicker(checks.PeriodicHealthCheckInterval)
@@ -77,7 +77,7 @@ func wireSingleChainDependencies(config *config.SingleChainConfig, logger *zap.L
 		logger: logger,
 	}
 
-	return SingleChainDependencyContainer{
+	return SingleChainObjectGraph{
 		ChainName: config.ChainName,
 		Router:    router,
 		handler:   handler,

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -77,6 +77,19 @@ func wireDependenciesForAllChains(
 		logger:           rootLogger,
 	}
 
+	mux := newServeMux(healthCheckHandler, singleChainDependencies, rootLogger)
+
+	return objectGraph{
+		routerCollection: routerCollection,
+		handler:          mux,
+	}
+}
+
+func newServeMux(
+	healthCheckHandler *HealthCheckHandler,
+	singleChainDependencies []singleChainObjectGraph,
+	rootLogger *zap.Logger,
+) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.Handle("/health", healthCheckHandler)
 
@@ -85,8 +98,5 @@ func wireDependenciesForAllChains(
 		rootLogger.Info("Registered handler for chain.", zap.String("Path", container.handler.path), zap.String("chainName", container.chainName))
 	}
 
-	return objectGraph{
-		routerCollection: routerCollection,
-		handler:          mux,
-	}
+	return mux
 }

--- a/internal/server/rpc_handler.go
+++ b/internal/server/rpc_handler.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
+	"github.com/satsuma-data/node-gateway/internal/route"
+	"github.com/satsuma-data/node-gateway/internal/util"
+	"go.uber.org/zap"
+	"golang.org/x/exp/slices"
+)
+
+const defaultReadHeaderTimeout = 10 * time.Second
+
+type RPCHandler struct {
+	router route.Router
+	logger *zap.Logger
+	path   string
+}
+
+func (h *RPCHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
+	if req.URL.Path != h.path {
+		panic(fmt.Sprintf("Unexpected request with path %s to handler for path %s!", req.URL.Path, h.path))
+	}
+
+	if req.Method != http.MethodPost {
+		respondJSON(h.logger, writer, "Method not allowed.", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx := util.NewContext(context.Background(), getClientID(req))
+
+	headerContentType := req.Header.Get("Content-Type")
+	// Content-Type SHOULD be 'application/json-rpc' but MAY be
+	// 'application/json' or 'application/jsonrequest'.
+	// See https://www.jsonrpc.org/historical/json-rpc-over-http.html.
+	if !slices.Contains([]string{"application/json", "application/json-rpc", "application/jsonrequest"}, headerContentType) {
+		respondJSON(h.logger, writer, "Content-Type not supported.", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	requestBody, err := jsonrpc.DecodeRequestBody(req)
+	if err != nil {
+		errMsg := fmt.Sprintf("Request body could not be parsed, err: %s", err.Error())
+		resp := jsonrpc.CreateErrorJSONRPCResponseBody(errMsg, jsonrpc.InternalServerErrorCode)
+		h.logger.Error(errMsg)
+		respondJSONRPC(h.logger, writer, resp, http.StatusBadRequest)
+
+		return
+	}
+
+	h.logger.Debug("Request received.", zap.String("method", req.Method), zap.String("path", req.URL.Path), zap.String("query", req.URL.RawQuery), zap.Any("body", requestBody))
+
+	upstreamID, respBody, resp, err := h.router.Route(ctx, requestBody)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if err != nil {
+		switch e := err.(type) {
+		case jsonrpc.DecodeError:
+			respondRaw(nil, writer, e.Content, http.StatusOK)
+			return
+		default:
+			resp := jsonrpc.CreateErrorJSONRPCResponseBodyWithRequest(fmt.Sprintf("Request could not be routed, err: %s", err.Error()), jsonrpc.InternalServerErrorCode, requestBody)
+			respondJSONRPC(h.logger, writer, resp, http.StatusInternalServerError)
+
+			return
+		}
+	}
+
+	writer.Header().Set("X-Upstream-ID", upstreamID)
+	respondJSONRPC(h.logger, writer, respBody, resp.StatusCode)
+
+	h.logger.Debug("Request successfully routed.", zap.Any("requestBody", requestBody))
+}
+
+func getClientID(req *http.Request) string {
+	// Try to get the id of the `client` via query parameter. Admittedly this is a little hacky, but it won't break
+	// functionality as query params aren't used in JSON RPC.
+	// The reason we're using query param is because client code may be hard to modify, e.g. graph-nodes, while using
+	// query param is part of the RPC URL which is usually supplied as a config to the client.
+	// A better solution is to pass the client via an HTTP header.
+	if clientID := req.URL.Query().Get("client"); clientID != "" {
+		return clientID
+	}
+
+	return "unknown"
+}
+
+func respondJSONRPC(
+	logger *zap.Logger,
+	writer http.ResponseWriter,
+	response jsonrpc.ResponseBody,
+	httpStatusCode int,
+) {
+	if response == nil {
+		writer.WriteHeader(httpStatusCode)
+		return
+	}
+
+	respBytes, err := response.Encode()
+	if err != nil {
+		logger.Error("Failed to serialize response.", zap.Error(err), zap.String("response", string(respBytes)))
+		return
+	}
+
+	writer.Header().Set("Content-Type", "application/json")
+
+	// Note: Call `WriteHeader` last otherwise headers won't get written.
+	// See Header() on the http.ResponseWriter interface for more information.
+	writer.WriteHeader(httpStatusCode)
+
+	if i, err := writer.Write(respBytes); err != nil {
+		logger.Error("Failed to write JSON RPC response body.", zap.Error(err), zap.Int("bytesWritten", i), zap.String("response", string(respBytes)))
+		return
+	}
+}
+
+func respondJSON(logger *zap.Logger, writer http.ResponseWriter, message string, httpStatusCode int) {
+	resp := make(map[string]string)
+	if message != "" {
+		resp["message"] = message
+	}
+
+	writer.Header().Set("Content-Type", "application/json")
+
+	// Note: Call `WriteHeader` last otherwise headers won't get written.
+	// See Header() on the http.ResponseWriter interface for more information.
+	writer.WriteHeader(httpStatusCode)
+
+	jsonResp, _ := json.Marshal(resp)
+	if i, err := writer.Write(jsonResp); err != nil {
+		logger.Error("Failed to write response body.", zap.Error(err), zap.Int("bytesWritten", i), zap.String("response", string(jsonResp)))
+		return
+	}
+}
+
+func respondRaw(logger *zap.Logger, writer http.ResponseWriter, body []byte, httpStatusCode int) {
+	writer.WriteHeader(httpStatusCode)
+
+	if i, err := writer.Write(body); err != nil {
+		logger.Error("Failed to write raw response body.", zap.Error(err), zap.Int("bytesWritten", i), zap.String("response", string(body)))
+		return
+	}
+}

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -7,14 +7,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/satsuma-data/node-gateway/internal/checks"
-	"github.com/satsuma-data/node-gateway/internal/client"
-	"github.com/satsuma-data/node-gateway/internal/metadata"
-
 	conf "github.com/satsuma-data/node-gateway/internal/config"
 	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
 
-	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/route"
 	"github.com/satsuma-data/node-gateway/internal/util"
 	"go.uber.org/zap"
@@ -30,12 +25,6 @@ type RPCServer struct {
 	httpServer *http.Server
 	routers    []route.Router
 	config     conf.Config
-}
-
-type SingleChainDependencyContainer struct {
-	ChainName string
-	Router    route.Router
-	handler   *RPCHandler
 }
 
 func NewRPCServer(config conf.Config, rootLogger *zap.Logger) RPCServer {
@@ -64,71 +53,6 @@ func NewRPCServer(config conf.Config, rootLogger *zap.Logger) RPCServer {
 	}
 
 	return *rpcServer
-}
-
-func wireDependenciesForAllChains(
-	config conf.Config,
-	rootLogger *zap.Logger,
-) DependencyContainer {
-	var singleChainDependencies []SingleChainDependencyContainer
-	for chainIndex := range config.Chains {
-		currentChainConfig := &config.Chains[chainIndex]
-		childLogger := rootLogger.With(zap.String("chainName", currentChainConfig.ChainName))
-
-		dependencyContainer := wireSingleChainDependencies(currentChainConfig, childLogger)
-		singleChainDependencies = append(singleChainDependencies, dependencyContainer)
-	}
-
-	healthCheckHandler := &HealthCheckHandler{
-		singleChainDependencies: singleChainDependencies,
-		logger:                  rootLogger,
-	}
-
-	mux := http.NewServeMux()
-	mux.Handle("/health", healthCheckHandler)
-
-	for _, container := range singleChainDependencies {
-		mux.Handle(container.handler.path, container.handler)
-	}
-
-	return DependencyContainer{
-		singleChainDependencies: singleChainDependencies,
-		handler:                 mux,
-	}
-}
-
-type DependencyContainer struct {
-	singleChainDependencies []SingleChainDependencyContainer
-	handler                 *http.ServeMux
-}
-
-func wireSingleChainDependencies(config *conf.SingleChainConfig, logger *zap.Logger) SingleChainDependencyContainer {
-	metricContainer := metrics.NewContainer(config.ChainName)
-	chainMetadataStore := metadata.NewChainMetadataStore()
-	ticker := time.NewTicker(checks.PeriodicHealthCheckInterval)
-	healthCheckManager := checks.NewHealthCheckManager(client.NewEthClient, config.Upstreams, chainMetadataStore, ticker, metricContainer, logger)
-
-	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.SimpleStateOrTracePresent, route.NearGlobalMaxHeight}
-	nodeFilter := route.CreateNodeFilter(enabledNodeFilters, healthCheckManager, chainMetadataStore, logger, &config.Routing)
-	routingStrategy := route.FilteringRoutingStrategy{
-		NodeFilter:      nodeFilter,
-		BackingStrategy: route.NewPriorityRoundRobinStrategy(logger),
-		Logger:          logger,
-	}
-
-	router := route.NewRouter(config.Upstreams, config.Groups, chainMetadataStore, healthCheckManager, &routingStrategy, metricContainer, logger)
-
-	handler := &RPCHandler{
-		path:   "/" + config.ChainName,
-		router: router,
-		logger: logger,
-	}
-
-	return SingleChainDependencyContainer{
-		ChainName: config.ChainName,
-		Router:    router,
-		handler:   handler,
-	}
 }
 
 func (s *RPCServer) Start() error {

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -67,7 +67,7 @@ func (s *RPCServer) Shutdown() error {
 }
 
 type HealthCheckHandler struct {
-	singleChainDependencies []SingleChainObjectGraph
+	singleChainDependencies []singleChainObjectGraph
 	logger                  *zap.Logger
 }
 

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -43,7 +43,7 @@ func NewRPCServer(config conf.Config, rootLogger *zap.Logger) RPCServer {
 
 	var routers []route.Router
 	for _, dependency := range dependencyContainer.singleChainGraphs {
-		routers = append(routers, dependency.Router)
+		routers = append(routers, dependency.router)
 	}
 
 	rpcServer := &RPCServer{
@@ -81,7 +81,7 @@ func (h *HealthCheckHandler) ServeHTTP(writer http.ResponseWriter, _ *http.Reque
 
 func (h *HealthCheckHandler) areAllRoutersInitialized() bool {
 	for _, singleChainDependencyContainer := range h.singleChainDependencies {
-		if !singleChainDependencyContainer.Router.IsInitialized() {
+		if !singleChainDependencyContainer.router.IsInitialized() {
 			return false
 		}
 	}

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -41,7 +41,7 @@ func NewRPCServer(config conf.Config, rootLogger *zap.Logger) RPCServer {
 		ReadHeaderTimeout: defaultReadHeaderTimeout,
 	}
 
-	var routers []route.Router
+	routers := make([]route.Router, len(dependencyContainer.singleChainGraphs))
 	for _, dependency := range dependencyContainer.singleChainGraphs {
 		routers = append(routers, dependency.router)
 	}
@@ -59,6 +59,7 @@ func (s *RPCServer) Start() error {
 	for _, router := range s.routers {
 		router.Start()
 	}
+
 	return s.httpServer.ListenAndServe()
 }
 
@@ -67,8 +68,8 @@ func (s *RPCServer) Shutdown() error {
 }
 
 type HealthCheckHandler struct {
-	singleChainDependencies []singleChainObjectGraph
 	logger                  *zap.Logger
+	singleChainDependencies []singleChainObjectGraph
 }
 
 func (h *HealthCheckHandler) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
@@ -85,13 +86,14 @@ func (h *HealthCheckHandler) areAllRoutersInitialized() bool {
 			return false
 		}
 	}
+
 	return true
 }
 
 type RPCHandler struct {
-	path   string
 	router route.Router
 	logger *zap.Logger
+	path   string
 }
 
 func (h *RPCHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -32,7 +32,7 @@ type RPCServer struct {
 	config     conf.Config
 }
 
-type SingleChainDependendencyContainer struct {
+type SingleChainDependencyContainer struct {
 	ChainName string
 	Router    route.Router
 	handler   *RPCHandler
@@ -70,7 +70,7 @@ func wireDependenciesForAllChains(
 	config conf.Config,
 	rootLogger *zap.Logger,
 ) DependencyContainer {
-	var singleChainDependencies []SingleChainDependendencyContainer
+	var singleChainDependencies []SingleChainDependencyContainer
 	for chainIndex := range config.Chains {
 		currentChainConfig := &config.Chains[chainIndex]
 		childLogger := rootLogger.With(zap.String("chainName", currentChainConfig.ChainName))
@@ -98,11 +98,11 @@ func wireDependenciesForAllChains(
 }
 
 type DependencyContainer struct {
-	singleChainDependencies []SingleChainDependendencyContainer
+	singleChainDependencies []SingleChainDependencyContainer
 	handler                 *http.ServeMux
 }
 
-func wireSingleChainDependencies(config *conf.SingleChainConfig, logger *zap.Logger) SingleChainDependendencyContainer {
+func wireSingleChainDependencies(config *conf.SingleChainConfig, logger *zap.Logger) SingleChainDependencyContainer {
 	metricContainer := metrics.NewContainer(config.ChainName)
 	chainMetadataStore := metadata.NewChainMetadataStore()
 	ticker := time.NewTicker(checks.PeriodicHealthCheckInterval)
@@ -124,7 +124,7 @@ func wireSingleChainDependencies(config *conf.SingleChainConfig, logger *zap.Log
 		logger: logger,
 	}
 
-	return SingleChainDependendencyContainer{
+	return SingleChainDependencyContainer{
 		ChainName: config.ChainName,
 		Router:    router,
 		handler:   handler,
@@ -143,7 +143,7 @@ func (s *RPCServer) Shutdown() error {
 }
 
 type HealthCheckHandler struct {
-	singleChainDependencies []SingleChainDependendencyContainer
+	singleChainDependencies []SingleChainDependencyContainer
 	logger                  *zap.Logger
 }
 

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -33,9 +33,10 @@ type RPCServer struct {
 }
 
 func NewRPCServer(config conf.Config, rootLogger *zap.Logger) RPCServer {
-	childLogger := rootLogger.With(zap.String("chainName", config.ChainName))
+	currentChainConfig := &config.Chains[0]
+	childLogger := rootLogger.With(zap.String("chainName", currentChainConfig.ChainName))
 
-	dependencyContainer := wireDependencies(config, childLogger)
+	dependencyContainer := wireSingleChainDependencies(currentChainConfig, childLogger)
 	router := dependencyContainer.router
 	handler := &RPCHandler{
 		router: router,
@@ -76,7 +77,7 @@ type DependencyContainer struct {
 	metricsContainer *metrics.Container
 }
 
-func wireDependencies(config conf.Config, logger *zap.Logger) *DependencyContainer {
+func wireSingleChainDependencies(config *conf.SingleChainConfig, logger *zap.Logger) *DependencyContainer {
 	metricContainer := metrics.NewContainer(config.ChainName)
 	chainMetadataStore := metadata.NewChainMetadataStore()
 	ticker := time.NewTicker(checks.PeriodicHealthCheckInterval)

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -42,7 +42,7 @@ func NewRPCServer(config conf.Config, rootLogger *zap.Logger) RPCServer {
 	}
 
 	var routers []route.Router
-	for _, dependency := range dependencyContainer.singleChainDependencies {
+	for _, dependency := range dependencyContainer.singleChainGraphs {
 		routers = append(routers, dependency.Router)
 	}
 

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -2,23 +2,15 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	conf "github.com/satsuma-data/node-gateway/internal/config"
-	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
-
 	"github.com/satsuma-data/node-gateway/internal/route"
-	"github.com/satsuma-data/node-gateway/internal/util"
-	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 )
 
 const (
-	defaultServerPort        = 8080
-	defaultReadHeaderTimeout = 10 * time.Second
+	defaultServerPort = 8080
 )
 
 type RPCServer struct {
@@ -58,137 +50,4 @@ func (s *RPCServer) Start() error {
 
 func (s *RPCServer) Shutdown() error {
 	return s.httpServer.Shutdown(context.Background())
-}
-
-type RPCHandler struct {
-	router route.Router
-	logger *zap.Logger
-	path   string
-}
-
-func (h *RPCHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
-	if req.URL.Path != h.path {
-		panic(fmt.Sprintf("Unexpected request with path %s to handler for path %s!", req.URL.Path, h.path))
-	}
-
-	if req.Method != http.MethodPost {
-		respondJSON(h.logger, writer, "Method not allowed.", http.StatusMethodNotAllowed)
-		return
-	}
-
-	ctx := util.NewContext(context.Background(), getClientID(req))
-
-	headerContentType := req.Header.Get("Content-Type")
-	// Content-Type SHOULD be 'application/json-rpc' but MAY be
-	// 'application/json' or 'application/jsonrequest'.
-	// See https://www.jsonrpc.org/historical/json-rpc-over-http.html.
-	if !slices.Contains([]string{"application/json", "application/json-rpc", "application/jsonrequest"}, headerContentType) {
-		respondJSON(h.logger, writer, "Content-Type not supported.", http.StatusUnsupportedMediaType)
-		return
-	}
-
-	requestBody, err := jsonrpc.DecodeRequestBody(req)
-	if err != nil {
-		errMsg := fmt.Sprintf("Request body could not be parsed, err: %s", err.Error())
-		resp := jsonrpc.CreateErrorJSONRPCResponseBody(errMsg, jsonrpc.InternalServerErrorCode)
-		h.logger.Error(errMsg)
-		respondJSONRPC(h.logger, writer, resp, http.StatusBadRequest)
-
-		return
-	}
-
-	h.logger.Debug("Request received.", zap.String("method", req.Method), zap.String("path", req.URL.Path), zap.String("query", req.URL.RawQuery), zap.Any("body", requestBody))
-
-	upstreamID, respBody, resp, err := h.router.Route(ctx, requestBody)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
-
-	if err != nil {
-		switch e := err.(type) {
-		case jsonrpc.DecodeError:
-			respondRaw(nil, writer, e.Content, http.StatusOK)
-			return
-		default:
-			resp := jsonrpc.CreateErrorJSONRPCResponseBodyWithRequest(fmt.Sprintf("Request could not be routed, err: %s", err.Error()), jsonrpc.InternalServerErrorCode, requestBody)
-			respondJSONRPC(h.logger, writer, resp, http.StatusInternalServerError)
-
-			return
-		}
-	}
-
-	writer.Header().Set("X-Upstream-ID", upstreamID)
-	respondJSONRPC(h.logger, writer, respBody, resp.StatusCode)
-
-	h.logger.Debug("Request successfully routed.", zap.Any("requestBody", requestBody))
-}
-
-func getClientID(req *http.Request) string {
-	// Try to get the id of the `client` via query parameter. Admittedly this is a little hacky, but it won't break
-	// functionality as query params aren't used in JSON RPC.
-	// The reason we're using query param is because client code may be hard to modify, e.g. graph-nodes, while using
-	// query param is part of the RPC URL which is usually supplied as a config to the client.
-	// A better solution is to pass the client via an HTTP header.
-	if clientID := req.URL.Query().Get("client"); clientID != "" {
-		return clientID
-	}
-
-	return "unknown"
-}
-
-func respondJSONRPC(
-	logger *zap.Logger,
-	writer http.ResponseWriter,
-	response jsonrpc.ResponseBody,
-	httpStatusCode int,
-) {
-	if response == nil {
-		writer.WriteHeader(httpStatusCode)
-		return
-	}
-
-	respBytes, err := response.Encode()
-	if err != nil {
-		logger.Error("Failed to serialize response.", zap.Error(err), zap.String("response", string(respBytes)))
-		return
-	}
-
-	writer.Header().Set("Content-Type", "application/json")
-
-	// Note: Call `WriteHeader` last otherwise headers won't get written.
-	// See Header() on the http.ResponseWriter interface for more information.
-	writer.WriteHeader(httpStatusCode)
-
-	if i, err := writer.Write(respBytes); err != nil {
-		logger.Error("Failed to write JSON RPC response body.", zap.Error(err), zap.Int("bytesWritten", i), zap.String("response", string(respBytes)))
-		return
-	}
-}
-
-func respondJSON(logger *zap.Logger, writer http.ResponseWriter, message string, httpStatusCode int) {
-	resp := make(map[string]string)
-	if message != "" {
-		resp["message"] = message
-	}
-
-	writer.Header().Set("Content-Type", "application/json")
-
-	// Note: Call `WriteHeader` last otherwise headers won't get written.
-	// See Header() on the http.ResponseWriter interface for more information.
-	writer.WriteHeader(httpStatusCode)
-
-	jsonResp, _ := json.Marshal(resp)
-	if i, err := writer.Write(jsonResp); err != nil {
-		logger.Error("Failed to write response body.", zap.Error(err), zap.Int("bytesWritten", i), zap.String("response", string(jsonResp)))
-		return
-	}
-}
-
-func respondRaw(logger *zap.Logger, writer http.ResponseWriter, body []byte, httpStatusCode int) {
-	writer.WriteHeader(httpStatusCode)
-
-	if i, err := writer.Write(body); err != nil {
-		logger.Error("Failed to write raw response body.", zap.Error(err), zap.Int("bytesWritten", i), zap.String("response", string(body)))
-		return
-	}
 }

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -24,7 +24,6 @@ const (
 type RPCServer struct {
 	httpServer       *http.Server
 	routerCollection route.RouterCollection
-	config           conf.Config
 }
 
 func NewRPCServer(config conf.Config, rootLogger *zap.Logger) RPCServer {
@@ -44,7 +43,6 @@ func NewRPCServer(config conf.Config, rootLogger *zap.Logger) RPCServer {
 	rpcServer := &RPCServer{
 		httpServer:       httpServer,
 		routerCollection: dependencyContainer.routerCollection,
-		config:           config,
 	}
 
 	return *rpcServer

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -60,19 +60,6 @@ func (s *RPCServer) Shutdown() error {
 	return s.httpServer.Shutdown(context.Background())
 }
 
-type HealthCheckHandler struct {
-	logger           *zap.Logger
-	routerCollection route.RouterCollection
-}
-
-func (h *HealthCheckHandler) ServeHTTP(writer http.ResponseWriter, _ *http.Request) {
-	if h.routerCollection.IsInitialized() {
-		respondRaw(h.logger, writer, []byte("OK"), http.StatusOK)
-	} else {
-		respondRaw(h.logger, writer, []byte("Starting up"), http.StatusServiceUnavailable)
-	}
-}
-
 type RPCHandler struct {
 	router route.Router
 	logger *zap.Logger

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -26,9 +26,7 @@ type RPCServer struct {
 	routerCollection route.RouterCollection
 }
 
-func NewRPCServer(config conf.Config, rootLogger *zap.Logger) RPCServer {
-	dependencyContainer := wireDependenciesForAllChains(config, rootLogger)
-
+func NewHTTPServer(config conf.Config, handler *http.ServeMux) *http.Server {
 	port := defaultServerPort
 	if config.Global.Port > 0 {
 		port = config.Global.Port
@@ -36,16 +34,20 @@ func NewRPCServer(config conf.Config, rootLogger *zap.Logger) RPCServer {
 
 	httpServer := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),
-		Handler:           dependencyContainer.handler,
+		Handler:           handler,
 		ReadHeaderTimeout: defaultReadHeaderTimeout,
 	}
 
+	return httpServer
+}
+
+func NewRPCServer(httpServer *http.Server, routerCollection route.RouterCollection) *RPCServer {
 	rpcServer := &RPCServer{
 		httpServer:       httpServer,
-		routerCollection: dependencyContainer.routerCollection,
+		routerCollection: routerCollection,
 	}
 
-	return *rpcServer
+	return rpcServer
 }
 
 func (s *RPCServer) Start() error {

--- a/internal/server/web_server.go
+++ b/internal/server/web_server.go
@@ -67,7 +67,7 @@ func (s *RPCServer) Shutdown() error {
 }
 
 type HealthCheckHandler struct {
-	singleChainDependencies []SingleChainDependencyContainer
+	singleChainDependencies []SingleChainObjectGraph
 	logger                  *zap.Logger
 }
 

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -345,8 +345,8 @@ func startRouterAndHandler(t *testing.T, conf config.Config) *http.ServeMux {
 	testLogger := zap.L()
 
 	dependencyContainer := wireDependenciesForAllChains(conf, testLogger)
-	for chainIndex := range dependencyContainer.singleChainDependencies {
-		router := dependencyContainer.singleChainDependencies[chainIndex].Router
+	for chainIndex := range dependencyContainer.singleChainGraphs {
+		router := dependencyContainer.singleChainGraphs[chainIndex].Router
 		router.Start()
 
 		for router.IsInitialized() == false {

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -346,7 +346,7 @@ func startRouterAndHandler(t *testing.T, conf config.Config) *http.ServeMux {
 
 	dependencyContainer := wireDependenciesForAllChains(conf, testLogger)
 	for chainIndex := range dependencyContainer.singleChainGraphs {
-		router := dependencyContainer.singleChainGraphs[chainIndex].Router
+		router := dependencyContainer.singleChainGraphs[chainIndex].router
 		router.Start()
 
 		for router.IsInitialized() == false {

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -32,9 +32,11 @@ func TestServeHTTP_ForwardsToSoleHealthyUpstream(t *testing.T) {
 	}
 
 	conf := config.Config{
-		Upstreams: upstreamConfigs,
-		Groups:    nil,
-		Global:    config.GlobalConfig{},
+		Chains: []config.SingleChainConfig{{
+			Upstreams: upstreamConfigs,
+			Groups:    nil,
+		}},
+		Global: config.GlobalConfig{},
 	}
 
 	handler := startRouterAndHandler(conf)
@@ -104,9 +106,11 @@ func TestServeHTTP_ForwardsToCorrectNodeTypeBasedOnStatefulness(t *testing.T) {
 		{ID: archiveNodeGroupID, Priority: 1},
 	}
 	conf := config.Config{
-		Upstreams: upstreamConfigs,
-		Groups:    groupConfigs,
-		Global:    config.GlobalConfig{},
+		Chains: []config.SingleChainConfig{{
+			Upstreams: upstreamConfigs,
+			Groups:    groupConfigs,
+		}},
+		Global: config.GlobalConfig{},
 	}
 
 	handler := startRouterAndHandler(conf)
@@ -258,7 +262,8 @@ func executeRequest(t *testing.T, request jsonrpc.RequestBody, handler *RPCHandl
 
 func startRouterAndHandler(conf config.Config) *RPCHandler {
 	testLogger := zap.L()
-	dependencyContainer := wireDependencies(conf, testLogger)
+	currentChainConfig := &conf.Chains[0]
+	dependencyContainer := wireSingleChainDependencies(currentChainConfig, testLogger)
 	router := dependencyContainer.router
 	router.Start()
 

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -347,15 +347,15 @@ func startRouterAndHandler(t *testing.T, conf config.Config) *http.ServeMux {
 
 	testLogger := zap.L()
 
-	dependencyContainer := wireDependenciesForAllChains(conf, testLogger)
+	dependencyContainer := WireDependenciesForAllChains(conf, testLogger)
 
-	dependencyContainer.routerCollection.Start()
+	dependencyContainer.RouterCollection.Start()
 
-	for dependencyContainer.routerCollection.IsInitialized() == false {
+	for dependencyContainer.RouterCollection.IsInitialized() == false {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	handler := dependencyContainer.handler
+	handler := dependencyContainer.Handler
 
 	return handler
 }

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestMain(m *testing.M) {
 	loggingConfig := zap.NewDevelopmentConfig()
-	loggingConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	loggingConfig.Level = zap.NewAtomicLevelAt(zap.WarnLevel)
 	logger, err := loggingConfig.Build()
 	if err != nil {
 		panic(err.Error())

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -23,10 +23,12 @@ import (
 func TestMain(m *testing.M) {
 	loggingConfig := zap.NewDevelopmentConfig()
 	loggingConfig.Level = zap.NewAtomicLevelAt(zap.WarnLevel)
+
 	logger, err := loggingConfig.Build()
 	if err != nil {
 		panic(err.Error())
 	}
+
 	zap.ReplaceGlobals(logger)
 
 	os.Exit(m.Run())

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -319,6 +319,7 @@ func executeRequest(
 	handler *http.ServeMux,
 ) (int, jsonrpc.ResponseBody, http.Header) {
 	t.Helper()
+
 	requestBytes, _ := request.Encode()
 	req := httptest.NewRequest(http.MethodPost, "/"+chainName, bytes.NewReader(requestBytes))
 
@@ -347,13 +348,11 @@ func startRouterAndHandler(t *testing.T, conf config.Config) *http.ServeMux {
 	testLogger := zap.L()
 
 	dependencyContainer := wireDependenciesForAllChains(conf, testLogger)
-	for chainIndex := range dependencyContainer.singleChainGraphs {
-		router := dependencyContainer.singleChainGraphs[chainIndex].router
-		router.Start()
 
-		for router.IsInitialized() == false {
-			time.Sleep(10 * time.Millisecond)
-		}
+	dependencyContainer.routerCollection.Start()
+
+	for dependencyContainer.routerCollection.IsInitialized() == false {
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	handler := dependencyContainer.handler

--- a/internal/server/web_server_test.go
+++ b/internal/server/web_server_test.go
@@ -26,8 +26,8 @@ func TestHandleJSONRPCRequest_Success(t *testing.T) {
 		Result:  "results",
 		ID:      2,
 	}
-	router.On("Route", mock.Anything, mock.Anything).
-		Return(expectedRPCResponse,
+	router.EXPECT().Route(mock.Anything, mock.Anything).
+		Return("fakeUpstream", expectedRPCResponse,
 			&http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader("dummy")),
@@ -125,8 +125,8 @@ func TestHandleJSONRPCRequest_UnknownBodyField(t *testing.T) {
 func TestHandleJSONRPCRequest_NilJSONRPCResponse(t *testing.T) {
 	router := mocks.NewRouter(t)
 
-	router.On("Route", mock.Anything, mock.Anything).
-		Return(nil,
+	router.EXPECT().Route(mock.Anything, mock.Anything).
+		Return("", nil,
 			&http.Response{
 				StatusCode: http.StatusAccepted,
 				Body:       io.NopCloser(strings.NewReader("dummy")),
@@ -154,8 +154,8 @@ func TestHandleJSONRPCRequest_JSONRPCDecodeError(t *testing.T) {
 	router := mocks.NewRouter(t)
 	undecodableContent := []byte("content")
 
-	router.On("Route", mock.Anything, mock.Anything).
-		Return(nil, nil, jsonrpc.DecodeError{Err: errors.New("error decoding"), Content: undecodableContent})
+	router.EXPECT().Route(mock.Anything, mock.Anything).
+		Return("", nil, nil, jsonrpc.DecodeError{Err: errors.New("error decoding"), Content: undecodableContent})
 
 	handler := &RPCHandler{path: "/" + config.TestChainName, router: router, logger: zap.L()}
 

--- a/internal/server/web_server_test.go
+++ b/internal/server/web_server_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/satsuma-data/node-gateway/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
@@ -32,10 +33,10 @@ func TestHandleJSONRPCRequest_Success(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader("dummy")),
 			}, nil)
 
-	handler := &RPCHandler{router: router, logger: zap.L()}
+	handler := &RPCHandler{path: "/" + config.TestChainName, router: router, logger: zap.L()}
 
 	emptyJSONBody, _ := json.Marshal(map[string]any{})
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(emptyJSONBody))
+	req := httptest.NewRequest(http.MethodPost, "/"+config.TestChainName, bytes.NewReader(emptyJSONBody))
 	req.Header.Add("Content-Type", "application/json")
 
 	recorder := httptest.NewRecorder()
@@ -53,10 +54,10 @@ func TestHandleJSONRPCRequest_Success(t *testing.T) {
 
 func TestHandleJSONRPCRequest_NonPost(t *testing.T) {
 	router := mocks.NewRouter(t)
-	handler := &RPCHandler{router: router}
+	handler := &RPCHandler{path: "/" + config.TestChainName, router: router}
 
 	emptyJSONBody, _ := json.Marshal(map[string]any{})
-	req := httptest.NewRequest(http.MethodGet, "/", bytes.NewReader(emptyJSONBody))
+	req := httptest.NewRequest(http.MethodGet, "/"+config.TestChainName, bytes.NewReader(emptyJSONBody))
 	req.Header.Add("Content-Type", "application/json")
 
 	recorder := httptest.NewRecorder()
@@ -71,9 +72,9 @@ func TestHandleJSONRPCRequest_NonPost(t *testing.T) {
 
 func TestHandleJSONRPCRequest_NonJSONContentType(t *testing.T) {
 	router := mocks.NewRouter(t)
-	handler := &RPCHandler{router: router}
+	handler := &RPCHandler{path: "/" + config.TestChainName, router: router}
 
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte("body")))
+	req := httptest.NewRequest(http.MethodPost, "/"+config.TestChainName, bytes.NewReader([]byte("body")))
 	req.Header.Add("Content-Type", "text/plain")
 
 	recorder := httptest.NewRecorder()
@@ -88,9 +89,9 @@ func TestHandleJSONRPCRequest_NonJSONContentType(t *testing.T) {
 
 func TestHandleJSONRPCRequest_BadJSON(t *testing.T) {
 	router := mocks.NewRouter(t)
-	handler := &RPCHandler{router: router, logger: zap.L()}
+	handler := &RPCHandler{path: "/" + config.TestChainName, router: router, logger: zap.L()}
 
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte("{\"bad_json\": ")))
+	req := httptest.NewRequest(http.MethodPost, "/"+config.TestChainName, bytes.NewReader([]byte("{\"bad_json\": ")))
 	req.Header.Add("Content-Type", "application/json")
 
 	recorder := httptest.NewRecorder()
@@ -105,10 +106,10 @@ func TestHandleJSONRPCRequest_BadJSON(t *testing.T) {
 
 func TestHandleJSONRPCRequest_UnknownBodyField(t *testing.T) {
 	router := mocks.NewRouter(t)
-	handler := &RPCHandler{router: router, logger: zap.L()}
+	handler := &RPCHandler{path: "/" + config.TestChainName, router: router, logger: zap.L()}
 
 	emptyJSONBody, _ := json.Marshal(map[string]any{"unknown_field": "value"})
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(emptyJSONBody))
+	req := httptest.NewRequest(http.MethodPost, "/"+config.TestChainName, bytes.NewReader(emptyJSONBody))
 	req.Header.Add("Content-Type", "application/json")
 
 	recorder := httptest.NewRecorder()
@@ -131,10 +132,10 @@ func TestHandleJSONRPCRequest_NilJSONRPCResponse(t *testing.T) {
 				Body:       io.NopCloser(strings.NewReader("dummy")),
 			}, nil)
 
-	handler := &RPCHandler{router: router, logger: zap.L()}
+	handler := &RPCHandler{path: "/" + config.TestChainName, router: router, logger: zap.L()}
 
 	emptyJSONBody, _ := json.Marshal(map[string]any{})
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(emptyJSONBody))
+	req := httptest.NewRequest(http.MethodPost, "/"+config.TestChainName, bytes.NewReader(emptyJSONBody))
 	req.Header.Add("Content-Type", "application/json")
 
 	recorder := httptest.NewRecorder()
@@ -156,10 +157,10 @@ func TestHandleJSONRPCRequest_JSONRPCDecodeError(t *testing.T) {
 	router.On("Route", mock.Anything, mock.Anything).
 		Return(nil, nil, jsonrpc.DecodeError{Err: errors.New("error decoding"), Content: undecodableContent})
 
-	handler := &RPCHandler{router: router, logger: zap.L()}
+	handler := &RPCHandler{path: "/" + config.TestChainName, router: router, logger: zap.L()}
 
 	emptyJSONBody, _ := json.Marshal(map[string]any{})
-	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(emptyJSONBody))
+	req := httptest.NewRequest(http.MethodPost, "/"+config.TestChainName, bytes.NewReader(emptyJSONBody))
 	req.Header.Add("Content-Type", "application/json")
 
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
# Description

High-level overview of changes in this PR:
1. **Change config format to support multiple chains.** All config settings except for the Port are moved at the chain level.
2. **Create a separate object graph for each chain.** 
3. **Register per-chain handlers into the `ServeMux` at `/<chain_name>`.**
4. **Add an `X-Upstream-ID` header.** This is useful so that clients know which upstream a given request went to. In particular, I'm using it to verify the end-to-end test is behaving as expected.
5. **Enable logging in tests.** I was hitting some panics that we have logging for, but zap uses a no-op logger by default. I changed it to a WARN logger.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Added end-to-end test with two chains configured and verified that requests go to the correct object graph - both by checking the new `X-Upstream-ID` header, and by manually checking the logs.