### PR TITLE
feat: internal-release.sh to deploy to ECR

### DIFF
--- a/scripts/internal-release.sh
+++ b/scripts/internal-release.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -e 
+set -o pipefail
+
+BOLDGREEN="\033[32m"
+ENDCOLOR="\033[0m"
+
+REGISTRY_URL=694773929020.dkr.ecr.us-east-1.amazonaws.com
+
+LogStep() {
+  echo -e "${BOLDGREEN}##\n$1\n##${ENDCOLOR}"
+}
+
+Help()
+{
+   echo "This script builds and pushes the Docker image to ECR."
+   echo
+   echo "Usage: ./release.sh $COMMIT_HASH"
+   echo
+}
+
+COMMIT_HASH=$1
+
+if [ -z "$COMMIT_HASH" ]
+then
+  Help
+  exit 0
+fi
+
+VALID_LONG_GIT_SHA_REGEX="[a-f0-9]{40}"
+if [[ ! $COMMIT_HASH =~ $VALID_LONG_GIT_SHA_REGEX ]]
+then
+ echo "Invalid long commit hash."
+  exit 1
+fi
+
+if [ "$(git status --porcelain)" ]
+then 
+  echo "The working directory must be clean to perform a release."
+  exit 1
+fi
+
+LogStep "Docker login."
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 694773929020.dkr.ecr.us-east-1.amazonaws.com
+
+LogStep "Releasing commit $COMMIT_HASH."
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+LogStep "Checking out the commit to release."
+git checkout $COMMIT_HASH
+
+LogStep "Running code linter."
+golangci-lint run
+
+LogStep "Running tests."
+go test -v ./...
+
+LogStep "Cleaning the build directory."
+make clean
+
+LogStep "Building and pushing the image."
+make GIT_COMMIT_HASH=$COMMIT_HASH VERSION=$COMMIT_HASH DOCKER_HUB_REPO=$REGISTRY_URL/node-gateway build-and-push-image
+
+LogStep "Checking out the original commit."
+git checkout $CURRENT_BRANCH

--- a/scripts/public-release.sh
+++ b/scripts/public-release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# This script releases the image to our public DockerHub repository.
 
 set -e 
 set -o pipefail


### PR DESCRIPTION
# Description
* Ported over subgraph gateway's release.sh for an `internal-release`.sh - to deploy to ECR.
* For now, release is done locally and manually: `./scripts/iinternal-release.sh $GIT_COMMIT_SHA`.

Why not DockerHub? I think there are benefits to keeping it consistent with our other internal Docker images. Let's only use DockerHub for open source releases.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Deployed a version to ECR already 
