### PR TITLE
feat: route eth_getLogs to archive node

### DIFF
--- a/internal/metadata/request_metadata.go
+++ b/internal/metadata/request_metadata.go
@@ -3,4 +3,5 @@ package metadata
 type RequestMetadata struct {
 	IsStateRequired bool
 	IsTraceMethod   bool
+	IsLogMethod     bool
 }

--- a/internal/metadata/request_metadata_parser_test.go
+++ b/internal/metadata/request_metadata_parser_test.go
@@ -18,7 +18,7 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 		want RequestMetadata
 	}
 
-	testForSingleRequest := func(methodName string, isStateRequired, isTraceMethod bool) testArgs {
+	testForSingleRequest := func(methodName string, isStateRequired, isTraceMethod, isLogMethod bool) testArgs {
 		return testArgs{
 			args{
 				requestBody: &jsonrpc.SingleRequestBody{
@@ -29,11 +29,12 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 			RequestMetadata{
 				IsStateRequired: isStateRequired,
 				IsTraceMethod:   isTraceMethod,
+				IsLogMethod:     isLogMethod,
 			},
 		}
 	}
 
-	testForBatchRequest := func(testName string, methodNames []string, isStateRequired bool, isTraceMethod bool) testArgs {
+	testForBatchRequest := func(testName string, methodNames []string, isStateRequired bool, isTraceMethod, isLogMethod bool) testArgs {
 		requests := make([]jsonrpc.SingleRequestBody, 0)
 		for _, methodName := range methodNames {
 			requests = append(requests, jsonrpc.SingleRequestBody{
@@ -51,24 +52,26 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 			RequestMetadata{
 				IsStateRequired: isStateRequired,
 				IsTraceMethod:   isTraceMethod,
+				IsLogMethod:     isLogMethod,
 			},
 		}
 	}
 
 	tests := []testArgs{
-		testForSingleRequest("eth_call", true, false),
-		testForSingleRequest("eth_getBalance", true, false),
-		testForSingleRequest("eth_getBlockByNumber", false, false),
-		testForSingleRequest("eth_getTransactionReceipt", false, false),
-		testForSingleRequest("trace_filter", false, true),
-		testForSingleRequest("trace_replayBlockTransactions", false, true),
-		testForBatchRequest("batch eth_call", []string{"eth_call"}, true, false),
+		testForSingleRequest("eth_call", true, false, false),
+		testForSingleRequest("eth_getBalance", true, false, false),
+		testForSingleRequest("eth_getBlockByNumber", false, false, false),
+		testForSingleRequest("eth_getTransactionReceipt", false, false, false),
+		testForSingleRequest("trace_filter", false, true, false),
+		testForSingleRequest("trace_replayBlockTransactions", false, true, false),
+		testForSingleRequest("eth_getLogs", false, false, true),
+		testForBatchRequest("batch eth_call", []string{"eth_call"}, true, false, false),
 		testForBatchRequest("batch eth_call w/ eth_getTransactionReceipt",
-			[]string{"eth_call", "eth_getTransactionReceipt"}, true, false),
+			[]string{"eth_call", "eth_getTransactionReceipt"}, true, false, false),
 		testForBatchRequest("batch trace w/ eth_getTransactionReceipt",
-			[]string{"trace_filter", "eth_getTransactionReceipt"}, false, true),
-		testForBatchRequest("batch eth_call w/ eth_getTransactionReceipt and trace",
-			[]string{"eth_call", "eth_getTransactionReceipt", "trace_filter"}, true, true),
+			[]string{"trace_filter", "eth_getTransactionReceipt"}, false, true, false),
+		testForBatchRequest("batch eth_call w/ eth_getTransactionReceipt, trace, and eth_getLogs",
+			[]string{"eth_call", "eth_getTransactionReceipt", "trace_filter", "eth_getLogs"}, true, true, true),
 	}
 
 	for _, tt := range tests {

--- a/internal/route/node_filter_test.go
+++ b/internal/route/node_filter_test.go
@@ -93,7 +93,7 @@ func TestIsCloseToGlobalMaxHeight_Apply(t *testing.T) {
 	assert.True(t, filter.Apply(metadata.RequestMetadata{}, upstreamConfig))
 }
 
-func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {
+func TestArchiveNodeMethodFilter_Apply(t *testing.T) {
 	fullNodeConfig := config.UpstreamConfig{NodeType: config.Full}
 	archiveNodeConfig := config.UpstreamConfig{NodeType: config.Archive}
 
@@ -118,7 +118,7 @@ func TestSimpleIsStatePresentFilter_Apply(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := &SimpleIsStateOrTracePresent{logger: zap.L()}
+			f := &IsArchiveNodeMethod{logger: zap.L()}
 			ok := f.Apply(tt.args.requestMetadata, tt.args.upstreamConfig)
 			assert.Equalf(t, tt.want, ok, "Apply(%v, %v)", tt.args.requestMetadata, tt.args.upstreamConfig)
 		})

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -32,7 +32,7 @@ func wireSingleChainDependencies(chainConfig *config.SingleChainConfig, logger *
 	ticker := time.NewTicker(checks.PeriodicHealthCheckInterval)
 	healthCheckManager := checks.NewHealthCheckManager(client.NewEthClient, chainConfig.Upstreams, chainMetadataStore, ticker, metricContainer, logger)
 
-	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.SimpleStateOrTracePresent, route.NearGlobalMaxHeight}
+	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.ArchiveNodeMethod, route.NearGlobalMaxHeight}
 	nodeFilter := route.CreateNodeFilter(enabledNodeFilters, healthCheckManager, chainMetadataStore, logger, &chainConfig.Routing)
 	routingStrategy := route.FilteringRoutingStrategy{
 		NodeFilter:      nodeFilter,


### PR DESCRIPTION
# Description
From `indexing using single node vs gateway test`, we found that routing `eth_getLogs` to full nodes is much slower than routing them to archive nodes, which significantly slows down initial indexing.

The reason why `eth_getLogs` is slower seems be partially rooted in how the clients are implemented (e.g. Geth/Bor vs Erigon). Therefore a blanket filter like in this PR may not hold for all clients. Currently we only run Geth/Bor/Erigon so this should be OK.

https://www.notion.so/satsuma-xyz/Indexing-on-gateway-vs-single-node-25825148e5a648bda892339900889b22


## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Tested locally and verified `eth_getLogs` requests are getting routed to archive