### PR TITLE
fix: timeout for healthchecks

### DIFF
--- a/internal/checks/check.go
+++ b/internal/checks/check.go
@@ -11,6 +11,7 @@ import (
 const (
 	JSONRPCErrCodeMethodNotFound = -32601
 	MinimumPeerCount             = 5
+	RPCRequestTimeout            = 10 * time.Second
 )
 
 func isMethodNotSupportedErr(err error) bool {

--- a/internal/checks/peers.go
+++ b/internal/checks/peers.go
@@ -84,7 +84,10 @@ func (c *PeerCheck) runCheck() {
 	}
 
 	runCheck := func() {
-		peerCount, err := c.client.PeerCount(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), RPCRequestTimeout)
+		defer cancel()
+
+		peerCount, err := c.client.PeerCount(ctx)
 		if c.Err = err; c.Err != nil {
 			c.metricsContainer.PeerCountCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPRequest).Inc()
 			return

--- a/internal/checks/syncing.go
+++ b/internal/checks/syncing.go
@@ -82,7 +82,10 @@ func (c *SyncingCheck) runCheck() {
 	}
 
 	runCheck := func() {
-		result, err := c.client.SyncProgress(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), RPCRequestTimeout)
+		defer cancel()
+
+		result, err := c.client.SyncProgress(ctx)
 		if c.Err = err; err != nil {
 			c.metricsContainer.SyncStatusCheckErrors.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL, metrics.HTTPRequest).Inc()
 			return


### PR DESCRIPTION
# Description
Lack of timeouts was causing monitoring to get [stuck](https://github.com/satsuma-data/node-gateway/blob/e6e71622712e4563e91a66ff42986b2b00a3891b/internal/checks/manager.go#L161-L190) and prolonged the [outage](https://www.notion.so/satsuma-xyz/Polygon-stack-outage-104195e1f96e4c7da1de4746f739b637) yesterday.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

