### PR TITLE
fix: turn JSON RPC request body ID to pointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/samber/lo v1.36.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/rjeczalik/notify v0.9.1 h1:CLCKso/QK1snAlnhNR/CNvNiFU2saUtjV0bx3EwNeC
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
+github.com/samber/lo v1.36.0 h1:4LaOxH1mHnbDGhTVE0i1z8v/lWaQW8AIfOD3HU4mSaw=
+github.com/samber/lo v1.36.0/go.mod h1:HLeWcJRRyLKp3+/XBJvOrerCQn9mhdKMHyd7IRlgeQ8=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible h1:Bn1aCHHRnjv4Bl16T8rcaFjYSrGrIZvpiGO6P3Q4GpU=
 github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -538,6 +540,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -198,8 +198,9 @@ func CreateErrorJSONRPCResponseBodyWithRequest(message string, jsonRPCStatusCode
 	switch r := request.(type) {
 	case *SingleRequestBody:
 		response := CreateErrorJSONRPCResponseBody(message, jsonRPCStatusCode)
-		response.ID = *r.ID
-
+		if r.ID != nil {
+			response.ID = *r.ID
+		}
 		return response
 	case *BatchRequestBody:
 		subRequests := r.GetSubRequests()

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -201,6 +201,7 @@ func CreateErrorJSONRPCResponseBodyWithRequest(message string, jsonRPCStatusCode
 		if r.ID != nil {
 			response.ID = *r.ID
 		}
+
 		return response
 	case *BatchRequestBody:
 		subRequests := r.GetSubRequests()

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -19,10 +19,10 @@ type RequestBody interface {
 
 // See: https://www.jsonrpc.org/specification#request_object
 type SingleRequestBody struct {
+	ID             *int64 `json:"id,omitempty"`
 	JSONRPCVersion string `json:"jsonrpc,omitempty"`
 	Method         string `json:"method,omitempty"`
 	Params         []any  `json:"params,omitempty"`
-	ID             *int64 `json:"id,omitempty"`
 }
 
 func (b *SingleRequestBody) Encode() ([]byte, error) {

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -22,7 +22,7 @@ type SingleRequestBody struct {
 	JSONRPCVersion string `json:"jsonrpc,omitempty"`
 	Method         string `json:"method,omitempty"`
 	Params         []any  `json:"params,omitempty"`
-	ID             int64  `json:"id,omitempty"`
+	ID             *int64 `json:"id,omitempty"`
 }
 
 func (b *SingleRequestBody) Encode() ([]byte, error) {
@@ -63,7 +63,7 @@ type SingleResponseBody struct {
 	Result  any    `json:"result,omitempty"`
 	Error   *Error `json:"error,omitempty"`
 	JSONRPC string `json:"jsonrpc"`
-	ID      int    `json:"id"`
+	ID      int64  `json:"id"`
 }
 
 func (b *SingleResponseBody) Encode() ([]byte, error) {
@@ -198,7 +198,7 @@ func CreateErrorJSONRPCResponseBodyWithRequest(message string, jsonRPCStatusCode
 	switch r := request.(type) {
 	case *SingleRequestBody:
 		response := CreateErrorJSONRPCResponseBody(message, jsonRPCStatusCode)
-		response.ID = int(r.ID)
+		response.ID = *r.ID
 
 		return response
 	case *BatchRequestBody:
@@ -212,7 +212,7 @@ func CreateErrorJSONRPCResponseBodyWithRequest(message string, jsonRPCStatusCode
 					Code:    jsonRPCStatusCode,
 					Message: message,
 				},
-				ID: int(subReq.ID),
+				ID: *subReq.ID,
 			}
 			responses = append(responses, response)
 		}

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +23,7 @@ func TestEncodeAndDecodeRequests(t *testing.T) {
 				JSONRPCVersion: "2.0",
 				Method:         "web3_clientVersion",
 				Params:         []any{"hi"},
-				ID:             67,
+				ID:             lo.ToPtr[int64](67),
 			},
 		},
 		{
@@ -34,7 +35,7 @@ func TestEncodeAndDecodeRequests(t *testing.T) {
 						JSONRPCVersion: "2.0",
 						Method:         "web3_clientVersion",
 						Params:         []any{"hi"},
-						ID:             67,
+						ID:             lo.ToPtr[int64](67),
 					},
 				},
 			},
@@ -52,19 +53,19 @@ func TestEncodeAndDecodeRequests(t *testing.T) {
 						JSONRPCVersion: "2.0",
 						Method:         "web3_clientVersion",
 						Params:         []any{"hi"},
-						ID:             67,
+						ID:             lo.ToPtr[int64](67),
 					},
 					{
 						JSONRPCVersion: "2.0",
 						Method:         "web3_weee",
 						Params:         []any{"hi"},
-						ID:             68,
+						ID:             lo.ToPtr[int64](68),
 					},
 					{
 						JSONRPCVersion: "2.0",
 						Method:         "web3_something_else",
 						Params:         []any{"hello"},
-						ID:             69,
+						ID:             lo.ToPtr[int64](69),
 					},
 				},
 			},

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -17,6 +17,25 @@ func TestEncodeAndDecodeRequests(t *testing.T) {
 		body            string
 	}{
 		{
+			testName: "no ID",
+			body:     "{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}",
+			expectedRequest: &SingleRequestBody{
+				JSONRPCVersion: "2.0",
+				Method:         "web3_clientVersion",
+				Params:         []any{"hi"},
+			},
+		},
+		{
+			testName: "ID zero",
+			body:     "{\"id\":0,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}",
+			expectedRequest: &SingleRequestBody{
+				JSONRPCVersion: "2.0",
+				Method:         "web3_clientVersion",
+				Params:         []any{"hi"},
+				ID:             lo.ToPtr[int64](0),
+			},
+		},
+		{
 			testName: "single request",
 			body:     "{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}",
 			expectedRequest: &SingleRequestBody{

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -18,7 +18,7 @@ func TestEncodeAndDecodeRequests(t *testing.T) {
 	}{
 		{
 			testName: "single request",
-			body:     "{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"],\"id\":67}",
+			body:     "{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}",
 			expectedRequest: &SingleRequestBody{
 				JSONRPCVersion: "2.0",
 				Method:         "web3_clientVersion",
@@ -28,7 +28,7 @@ func TestEncodeAndDecodeRequests(t *testing.T) {
 		},
 		{
 			testName: "single request in batch",
-			body:     "[{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"],\"id\":67}]",
+			body:     "[{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}]",
 			expectedRequest: &BatchRequestBody{
 				Requests: []SingleRequestBody{
 					{
@@ -43,9 +43,9 @@ func TestEncodeAndDecodeRequests(t *testing.T) {
 		{
 			testName: "batch requests",
 			body: "[" +
-				"{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"],\"id\":67}," +
-				"{\"jsonrpc\":\"2.0\",\"method\":\"web3_weee\",\"params\":[\"hi\"],\"id\":68}," +
-				"{\"jsonrpc\":\"2.0\",\"method\":\"web3_something_else\",\"params\":[\"hello\"],\"id\":69}" +
+				"{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}," +
+				"{\"id\":68,\"jsonrpc\":\"2.0\",\"method\":\"web3_weee\",\"params\":[\"hi\"]}," +
+				"{\"id\":69,\"jsonrpc\":\"2.0\",\"method\":\"web3_something_else\",\"params\":[\"hello\"]}" +
 				"]",
 			expectedRequest: &BatchRequestBody{
 				Requests: []SingleRequestBody{

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -174,9 +174,9 @@ func (r *SimpleRouter) Route(
 	if body != nil {
 		// To help correlate request IDs to responses.
 		// It's the responsibility of the client to provide unique IDs.
-		reqIDToRequestMap := make(map[int]jsonrpc.SingleRequestBody)
+		reqIDToRequestMap := make(map[int64]jsonrpc.SingleRequestBody)
 		for _, req := range requestBody.GetSubRequests() {
-			reqIDToRequestMap[int(req.ID)] = req
+			reqIDToRequestMap[*req.ID] = req
 		}
 
 		for _, resp := range body.GetSubResponses() {

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -175,12 +175,14 @@ func (r *SimpleRouter) Route(
 		// To help correlate request IDs to responses.
 		// It's the responsibility of the client to provide unique IDs.
 		reqIDToRequestMap := make(map[int64]jsonrpc.SingleRequestBody)
+
 		for _, req := range requestBody.GetSubRequests() {
 			// JSONRPC requests without ID should not have a response.
 			// Defensively checking here to avoid dereferencing nil pointer.
 			if req.ID == nil {
 				continue
 			}
+
 			reqIDToRequestMap[*req.ID] = req
 		}
 

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/samber/lo"
 	"github.com/satsuma-data/node-gateway/internal/metadata"
 	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/types"
@@ -113,7 +112,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{ID: lo.ToPtr[int64](1)})
+	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)
@@ -159,7 +158,7 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{ID: lo.ToPtr[int64](1)})
+	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/satsuma-data/node-gateway/internal/metadata"
 	"github.com/satsuma-data/node-gateway/internal/metrics"
 	"github.com/satsuma-data/node-gateway/internal/types"
@@ -112,7 +113,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
+	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{ID: lo.ToPtr[int64](1)})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)
@@ -158,7 +159,7 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
+	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{ID: lo.ToPtr[int64](1)})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)

--- a/internal/server/web_server_e2e_test.go
+++ b/internal/server/web_server_e2e_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/samber/lo"
 	"github.com/satsuma-data/node-gateway/internal/config"
 	"github.com/satsuma-data/node-gateway/internal/jsonrpc"
 	"github.com/stretchr/testify/assert"
@@ -127,7 +128,7 @@ func TestServeHTTP_ForwardsToCorrectNodeTypeBasedOnStatefulness(t *testing.T) {
 
 			return jsonrpc.SingleResponseBody{
 				Result: hexutil.Uint64(expectedBlockTxCount),
-				ID:     int(request.ID),
+				ID:     *request.ID,
 			}
 		},
 	})
@@ -140,7 +141,7 @@ func TestServeHTTP_ForwardsToCorrectNodeTypeBasedOnStatefulness(t *testing.T) {
 
 			return jsonrpc.SingleResponseBody{
 				Result: hexutil.Uint64(expectedTransactionCount),
-				ID:     int(request.ID),
+				ID:     *request.ID,
 			}
 		},
 		nonStatefulMethod: func(t *testing.T, _ jsonrpc.SingleRequestBody) jsonrpc.SingleResponseBody {
@@ -217,7 +218,7 @@ func TestServeHTTP_ForwardsToCorrectNodeTypeBasedOnStatefulnessBatch(t *testing.
 
 			return jsonrpc.SingleResponseBody{
 				Result: hexutil.Uint64(expectedTransactionCount),
-				ID:     int(request.ID),
+				ID:     *request.ID,
 			}
 		},
 		nonStatefulMethod: func(t *testing.T, request jsonrpc.SingleRequestBody) jsonrpc.SingleResponseBody {
@@ -226,7 +227,7 @@ func TestServeHTTP_ForwardsToCorrectNodeTypeBasedOnStatefulnessBatch(t *testing.
 
 			return jsonrpc.SingleResponseBody{
 				Result: hexutil.Uint64(expectedBlockTxCount),
-				ID:     int(request.ID),
+				ID:     *request.ID,
 			}
 		},
 	})
@@ -262,7 +263,7 @@ func TestServeHTTP_ForwardsToCorrectNodeTypeBasedOnStatefulnessBatch(t *testing.
 	assert.Equal(t, http.StatusOK, statusCode)
 	assert.Equal(t, 2, len(responseBody.GetSubResponses()))
 
-	idsToExpectedResult := make(map[int]any)
+	idsToExpectedResult := make(map[int64]any)
 	for _, response := range responseBody.GetSubResponses() {
 		idsToExpectedResult[response.ID] = response.Result
 	}
@@ -282,7 +283,7 @@ func executeSingleRequest(
 	singleRequest := jsonrpc.SingleRequestBody{
 		JSONRPCVersion: "2.0",
 		Method:         methodName,
-		ID:             1,
+		ID:             lo.ToPtr[int64](1),
 	}
 
 	return executeRequest(t, chainName, &singleRequest, handler)
@@ -302,7 +303,7 @@ func executeBatchRequest(
 		singleRequest := jsonrpc.SingleRequestBody{
 			JSONRPCVersion: "2.0",
 			Method:         methodName,
-			ID:             int64(i),
+			ID:             lo.ToPtr(int64(i)),
 		}
 		requests = append(requests, singleRequest)
 	}


### PR DESCRIPTION
# Description

JSON RPC requests can omit the ID field to signal that the request is a notification: https://www.jsonrpc.org/specification#notification. These notification requests are not expected to have a response.

The SingleRequestBody model in the jsonrpc module uses the `omitempty` tag on the ID field.  The default "zero" value for an int64 in Golang is zero.  This means that any JSONRPC requests with ID of zero will not have the ID field present.  This causes the request to look like a notification, and the resulting response will have content-length of zero as well.

The graph-node uses a library called rust-web3 to make the JSONRPC requests to node providers.  This library ends up making requests that have ID set to 0 in the request.  When pointed to the node-gateway, the request hits the bug explained above and the response body is empty. The graph-node is not able to deserialize the empty response body correctly and we see the error: `failed to deserialize response: data did not match any variant of untagged enum Output`.  Interally, graph-node uses a model named `Output` to deserialize the JSONRPC response, hence why `untagged enum Output` shows up in the error.

To prevent this, we can use a pointer for the ID field in the request model.  This prevents omitempty from removing the ID field when it is zero.  This approach is more favorable because we do not have control over the JSONRPC ID used in graph-node.

Fixed the tests to reflect the new field type.  Changed the SingleResponseBody ID to also be int64 to be more consistent.  A valid JSONRPC response will never have ID not set, so it is OK to not have it as a pointer.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Ran node-gateway locally and made requests with ID set to 0.  After the fix, we get a proper response:

```
curl -v "localhost:8080/mainnet" \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_getTransactionReceipt","params":["0xa7f0de85ac222baecfd6bd9e074c350347fceb368a925f82be2e92bc83ae9d3f"],"id":0,"jsonrpc":"2.0"}'
...
{"result":{"blockHash":"0x8f33faf77241a3e43ac014021b583dd5b1f6fed8c67b42bbf3ddd793ca4f56d2","blockNumber":"0xf55595","contractAddress":null,"cumulativeGasUsed":"0x3c4cca","effectiveGasPrice":"0x2eb3b65c8","from":"0x06082441dbc4f3dedec7e5c53507c28bde682dd7","gasUsed":"0x144cf","logs":[{"address":"0x4ed9c0dca0479bc64d8f4eb3007126d5791f7851","blockHash":"0x8f33faf77241a3e43ac014021b583dd5b1f6fed8c67b42bbf3ddd793ca4f56d2","blockNumber":"0xf55595","data":"0x000000000000000000000000000000000000000009157bc2e79f571c58c76ee3","logIndex":"0x7d","removed":false,"topics":["0x9e2c1201748a5c10b659169e27843c246931edf32ccc126c79505db2352fbc3b"],"transactionHash":"0xa7f0de85ac222baecfd6bd9e074c350347fceb368a925f82be2e92bc83ae9d3f","transactionIndex":"0x21"},{"address":"0xcc88a9d330da1133df3a7bd823b95e52511a6962","blockHash":"0x8f33faf77241a3e43ac014021b583dd5b1f6fed8c67b42bbf3ddd793ca4f56d2","blockNumber":"0xf55595","data":"0x4554482d41000000000000000000000000000000000000000000000000000000736166657479507269636500000000000000000000000000000000000000000000000000000000000000000000000000000000040d79a314623f673578189a70","logIndex":"0x7e","removed":false,
...
```