### PR TITLE
fix: only include auth headers if basic auth is defined

### DIFF
--- a/internal/client/ethereum_client.go
+++ b/internal/client/ethereum_client.go
@@ -39,7 +39,7 @@ type BasicAuthCredentials struct {
 type EthClientGetter func(url string, credentials *BasicAuthCredentials) (EthClient, error)
 
 func NewEthClient(url string, credentials *BasicAuthCredentials) (EthClient, error) {
-	if credentials == nil {
+	if credentials == nil || (credentials.Username == "" && credentials.Password == "") {
 		ctx, cancel := context.WithTimeout(context.Background(), clientDialTimeout)
 		defer cancel()
 

--- a/internal/route/request_executor.go
+++ b/internal/route/request_executor.go
@@ -44,8 +44,10 @@ func (r *RequestExecutor) routeToConfig(
 
 	httpReq.Header.Set("content-type", "application/json")
 
-	encodedCredentials := base64.StdEncoding.EncodeToString([]byte(configToRoute.BasicAuthConfig.Username + ":" + configToRoute.BasicAuthConfig.Password))
-	httpReq.Header.Set("Authorization", "Basic "+encodedCredentials)
+	if configToRoute.BasicAuthConfig.Username != "" && configToRoute.BasicAuthConfig.Password != "" {
+		encodedCredentials := base64.StdEncoding.EncodeToString([]byte(configToRoute.BasicAuthConfig.Username + ":" + configToRoute.BasicAuthConfig.Password))
+		httpReq.Header.Set("Authorization", "Basic "+encodedCredentials)
+	}
 
 	resp, err := r.httpClient.Do(httpReq)
 


### PR DESCRIPTION
# Description

Some node providers like Chainstack check auth headers and will 401 the request if the header is empty, even if we're using an unauthed endpoint. The fix is to not send auth headers for health checks and routing of requests if basic auth credentials aren't defined in the config.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Tested locally by hooking it up to a node provider that checks auth headers.
