### PR TITLE
feat: method-based routing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,8 +82,8 @@ type BasicAuthConfig struct {
 }
 
 type MethodsConfig struct {
-	Enabled  map[string]bool // Emulating `Set` data structure
-	Disabled map[string]bool // Emulating `Set` data structure
+	Enabled  map[string]bool `yaml:"enabled"`  // Emulating `Set` data structure
+	Disabled map[string]bool `yaml:"disabled"` // Emulating `Set` data structure
 }
 
 func (m *MethodsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"os"
+	"strings"
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
@@ -23,6 +24,7 @@ type UpstreamConfig struct {
 	WSURL             string            `yaml:"wsURL"`
 	GroupID           string            `yaml:"group"`
 	NodeType          NodeType          `yaml:"nodeType"`
+	Methods           MethodsConfig     `yaml:"methods"`
 }
 
 func (c *UpstreamConfig) isValid(groups []GroupConfig) bool {
@@ -77,6 +79,37 @@ type HealthCheckConfig struct {
 type BasicAuthConfig struct {
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
+}
+
+type MethodsConfig struct {
+	Enabled  map[string]bool // Emulating `Set` data structure
+	Disabled map[string]bool // Emulating `Set` data structure
+}
+
+func (m *MethodsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type MethodsConfigString struct {
+		Enabled  string
+		Disabled string
+	}
+
+	var methodsConfigString MethodsConfigString
+	err := unmarshal(&methodsConfigString)
+
+	if err != nil {
+		return err
+	}
+
+	m.Enabled = make(map[string]bool)
+	for _, method := range strings.Split(methodsConfigString.Enabled, ",") {
+		m.Enabled[method] = true
+	}
+
+	m.Disabled = make(map[string]bool)
+	for _, method := range strings.Split(methodsConfigString.Disabled, ",") {
+		m.Disabled[method] = true
+	}
+
+	return nil
 }
 
 type GroupConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,14 +17,14 @@ const (
 )
 
 type UpstreamConfig struct {
-	BasicAuthConfig   BasicAuthConfig   `yaml:"basicAuth"`
+	Methods           MethodsConfig     `yaml:"methods"`
 	HealthCheckConfig HealthCheckConfig `yaml:"healthCheck"`
+	BasicAuthConfig   BasicAuthConfig   `yaml:"basicAuth"`
 	ID                string            `yaml:"id"`
 	HTTPURL           string            `yaml:"httpURL"`
 	WSURL             string            `yaml:"wsURL"`
 	GroupID           string            `yaml:"group"`
 	NodeType          NodeType          `yaml:"nodeType"`
-	Methods           MethodsConfig     `yaml:"methods"`
 }
 
 func (c *UpstreamConfig) isValid(groups []GroupConfig) bool {
@@ -162,8 +162,8 @@ func (c *SingleChainConfig) isValid() bool {
 	isChainConfigValid := true
 	isChainConfigValid = isChainConfigValid && IsGroupsValid(c.Groups)
 
-	for _, upstream := range c.Upstreams {
-		isChainConfigValid = isChainConfigValid && upstream.isValid(c.Groups)
+	for idx := range c.Upstreams {
+		isChainConfigValid = isChainConfigValid && c.Upstreams[idx].isValid(c.Groups)
 	}
 
 	if c.ChainName == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -134,6 +134,9 @@ func TestParseConfig_ValidConfig(t *testing.T) {
               useWsForBlockHeight: true
             group: primary
             nodeType: full
+            methods:
+              enabled: eth_getStorageAt
+              disabled: eth_getBalance
           - id: ankr-polygon
             httpURL: "https://rpc.ankr.com/polygon"
             wsURL: "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}"
@@ -169,6 +172,10 @@ func TestParseConfig_ValidConfig(t *testing.T) {
 					},
 					GroupID:  "primary",
 					NodeType: Full,
+					Methods: MethodsConfig{
+						Enabled:  map[string]bool{"eth_getStorageAt": true},
+						Disabled: map[string]bool{"eth_getBalance": true},
+					},
 				},
 				{
 					ID:      "ankr-polygon",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -136,7 +136,7 @@ func TestParseConfig_ValidConfig(t *testing.T) {
             nodeType: full
             methods:
               enabled: eth_getStorageAt
-              disabled: eth_getBalance
+              disabled: eth_getBalance,getLogs
           - id: ankr-polygon
             httpURL: "https://rpc.ankr.com/polygon"
             wsURL: "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}"
@@ -174,7 +174,7 @@ func TestParseConfig_ValidConfig(t *testing.T) {
 					NodeType: Full,
 					Methods: MethodsConfig{
 						Enabled:  map[string]bool{"eth_getStorageAt": true},
-						Disabled: map[string]bool{"eth_getBalance": true},
+						Disabled: map[string]bool{"eth_getBalance": true, "getLogs": true},
 					},
 				},
 				{

--- a/internal/metadata/request_metadata.go
+++ b/internal/metadata/request_metadata.go
@@ -1,7 +1,5 @@
 package metadata
 
 type RequestMetadata struct {
-	IsStateRequired bool
-	IsTraceMethod   bool
-	IsLogMethod     bool
+	Methods         []string
 }

--- a/internal/metadata/request_metadata.go
+++ b/internal/metadata/request_metadata.go
@@ -1,5 +1,5 @@
 package metadata
 
 type RequestMetadata struct {
-	Methods         []string
+	Methods []string
 }

--- a/internal/metadata/request_metadata_parser.go
+++ b/internal/metadata/request_metadata_parser.go
@@ -10,68 +10,19 @@ func (p *RequestMetadataParser) Parse(requestBody jsonrpc.RequestBody) RequestMe
 	switch requestBody.(type) {
 	case *jsonrpc.SingleRequestBody:
 		return RequestMetadata{
-			IsStateRequired: isStateRequiredForMethod(requestBody.GetMethod()),
-			IsTraceMethod:   isTraceMethod(requestBody.GetMethod()),
-			IsLogMethod:     isLogMethod(requestBody.GetMethod()),
+			Methods: []string{requestBody.GetMethod()},
 		}
 	case *jsonrpc.BatchRequestBody:
 		result := RequestMetadata{
-			IsStateRequired: false,
-			IsTraceMethod:   false,
-			IsLogMethod:     false,
+			Methods: []string{},
 		}
 
 		for _, requestBody := range requestBody.GetSubRequests() {
-			if isStateRequiredForMethod(requestBody.Method) {
-				result.IsStateRequired = true
-			}
-
-			if isTraceMethod(requestBody.Method) {
-				result.IsTraceMethod = true
-			}
-
-			if isLogMethod(requestBody.Method) {
-				result.IsLogMethod = true
-			}
-
-			if result.IsStateRequired && result.IsTraceMethod && result.IsLogMethod {
-				break
-			}
+			result.Methods = append(result.Methods, requestBody.Method)
 		}
 
 		return result
 	default:
 		panic("Invalid request body type   ")
-	}
-}
-
-func isStateRequiredForMethod(method string) bool {
-	switch method {
-	case "eth_getBalance", "eth_getStorageAt", "eth_getTransactionCount", "eth_getCode", "eth_call", "eth_estimateGas":
-		// List of state methods: https://ethereum.org/en/developers/docs/apis/json-rpc/#state_methods
-		return true
-	default:
-		return false
-	}
-}
-
-func isTraceMethod(method string) bool {
-	switch method {
-	case "trace_filter", "trace_block", "trace_get", "trace_transaction", "trace_call", "trace_callMany",
-		"trace_rawTransaction", "trace_replayBlockTransactions", "trace_replayTransaction":
-		// List of trace methods: https://openethereum.github.io/JSONRPC-trace-module
-		return true
-	default:
-		return false
-	}
-}
-
-func isLogMethod(method string) bool {
-	switch method {
-	case "eth_getLogs":
-		// There are several log methods, but right now we only care about `eth_getLogs`.
-		return true
-	default:
-		return false
 	}
 }

--- a/internal/metadata/request_metadata_parser_test.go
+++ b/internal/metadata/request_metadata_parser_test.go
@@ -18,7 +18,7 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 		want RequestMetadata
 	}
 
-	testForSingleRequest := func(methodName string, isStateRequired, isTraceMethod, isLogMethod bool) testArgs {
+	testForSingleRequest := func(methodName string) testArgs {
 		return testArgs{
 			args{
 				requestBody: &jsonrpc.SingleRequestBody{
@@ -27,14 +27,12 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 			},
 			methodName,
 			RequestMetadata{
-				IsStateRequired: isStateRequired,
-				IsTraceMethod:   isTraceMethod,
-				IsLogMethod:     isLogMethod,
+				Methods: []string{methodName},
 			},
 		}
 	}
 
-	testForBatchRequest := func(testName string, methodNames []string, isStateRequired bool, isTraceMethod, isLogMethod bool) testArgs {
+	testForBatchRequest := func(testName string, methodNames []string) testArgs {
 		requests := make([]jsonrpc.SingleRequestBody, 0)
 		for _, methodName := range methodNames {
 			requests = append(requests, jsonrpc.SingleRequestBody{
@@ -50,28 +48,15 @@ func TestRequestMetadataParser_Parse(t *testing.T) {
 			},
 			testName,
 			RequestMetadata{
-				IsStateRequired: isStateRequired,
-				IsTraceMethod:   isTraceMethod,
-				IsLogMethod:     isLogMethod,
+				Methods: methodNames,
 			},
 		}
 	}
 
 	tests := []testArgs{
-		testForSingleRequest("eth_call", true, false, false),
-		testForSingleRequest("eth_getBalance", true, false, false),
-		testForSingleRequest("eth_getBlockByNumber", false, false, false),
-		testForSingleRequest("eth_getTransactionReceipt", false, false, false),
-		testForSingleRequest("trace_filter", false, true, false),
-		testForSingleRequest("trace_replayBlockTransactions", false, true, false),
-		testForSingleRequest("eth_getLogs", false, false, true),
-		testForBatchRequest("batch eth_call", []string{"eth_call"}, true, false, false),
-		testForBatchRequest("batch eth_call w/ eth_getTransactionReceipt",
-			[]string{"eth_call", "eth_getTransactionReceipt"}, true, false, false),
-		testForBatchRequest("batch trace w/ eth_getTransactionReceipt",
-			[]string{"trace_filter", "eth_getTransactionReceipt"}, false, true, false),
+		testForSingleRequest("eth_call"),
 		testForBatchRequest("batch eth_call w/ eth_getTransactionReceipt, trace, and eth_getLogs",
-			[]string{"eth_call", "eth_getTransactionReceipt", "trace_filter", "eth_getLogs"}, true, true, true),
+			[]string{"eth_call", "eth_getTransactionReceipt", "trace_filter", "eth_getLogs"}),
 	}
 
 	for _, tt := range tests {

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -191,6 +191,9 @@ func isArchiveNodeMethod(method string) bool {
 	case "trace_filter", "trace_block", "trace_get", "trace_transaction", "trace_call", "trace_callMany",
 		"trace_rawTransaction", "trace_replayBlockTransactions", "trace_replayTransaction":
 		return true
+	case "eth_getLogs":
+		// Jan 25 2022 - Hack until we update configs to use the new `Methods` block.
+		return true
 	default:
 		return false
 	}

--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -183,34 +183,51 @@ func (f *IsAtMaxHeightForGroup) Apply(_ metadata.RequestMetadata, upstreamConfig
 	return false
 }
 
-type IsArchiveNodeMethod struct {
+func isArchiveNodeMethod(method string) bool {
+	switch method {
+	case "eth_getBalance", "eth_getStorageAt", "eth_getTransactionCount", "eth_getCode", "eth_call", "eth_estimateGas":
+		// List of state methods: https://ethereum.org/en/developers/docs/apis/json-rpc/#state_methods
+		return true
+	case "trace_filter", "trace_block", "trace_get", "trace_transaction", "trace_call", "trace_callMany",
+		"trace_rawTransaction", "trace_replayBlockTransactions", "trace_replayTransaction":
+		return true
+	default:
+		return false
+	}
+}
+
+type AreMethodsAllowed struct {
 	logger *zap.Logger
 }
 
-func (f *IsArchiveNodeMethod) Apply(
+func (f *AreMethodsAllowed) Apply(
 	requestMetadata metadata.RequestMetadata,
 	upstreamConfig *config.UpstreamConfig,
 ) bool {
-	// Both methods that are require state and trace need to be routed to archive nodes.
-	isStateOrTraceMethod := requestMetadata.IsStateRequired || requestMetadata.IsTraceMethod
+	for _, method := range requestMetadata.Methods {
+		// Check methods that are have been disabled on the upstream.
+		if ok := upstreamConfig.Methods.Disabled[method]; ok {
+			f.logger.Debug(
+				"Upstream method is disabled! Skipping upstream.",
+				zap.String("UpstreamID", upstreamConfig.ID),
+				zap.Any("RequestMetadata", requestMetadata),
+			)
 
-	// Methods that request logs should also get routed to archive nodes. While these requests
-	// *can* be served by full nodes, it's much slower than archive nodes.
-	// Note - this behavior has only been tested with Geth/Bor vs. Erigon.
-	isLogMethod := requestMetadata.IsLogMethod
-
-	if isStateOrTraceMethod || isLogMethod {
-		if upstreamConfig.NodeType == config.Archive {
-			return true
+			return false
 		}
 
-		f.logger.Debug(
-			"Upstream is not an archive node but request requires state, is a trace method, or is a log method!",
-			zap.String("UpstreamID", upstreamConfig.ID),
-			zap.Any("RequestMetadata", requestMetadata),
-		)
+		if isArchiveNodeMethod(method) && upstreamConfig.NodeType == config.Full {
+			// Check if method has been explicitly enabled on the upstream.
+			if ok := upstreamConfig.Methods.Enabled[method]; !ok {
+				f.logger.Debug(
+					"Upstream method is archive, nodeType is not archive, and method has not been enabled! Skipping upstream.",
+					zap.String("UpstreamID", upstreamConfig.ID),
+					zap.Any("RequestMetadata", requestMetadata),
+				)
 
-		return false
+				return false
+			}
+		}
 	}
 
 	return true
@@ -279,8 +296,8 @@ func CreateSingleNodeFilter(
 			chainMetadataStore: store,
 			logger:             logger,
 		}
-	case ArchiveNodeMethod:
-		return &IsArchiveNodeMethod{logger: logger}
+	case MethodsAllowed:
+		return &AreMethodsAllowed{logger: logger}
 	default:
 		panic("Unknown filter type " + filterName + "!")
 	}
@@ -293,5 +310,5 @@ const (
 	GlobalMaxHeight     NodeFilterType = "globalMaxHeight"
 	NearGlobalMaxHeight NodeFilterType = "nearGlobalMaxHeight"
 	MaxHeightForGroup   NodeFilterType = "maxHeightForGroup"
-	ArchiveNodeMethod   NodeFilterType = "archiveNodeMethod"
+	MethodsAllowed      NodeFilterType = "methodsAllowed"
 )

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -127,9 +127,9 @@ func (r *SimpleRouter) Route(
 
 	var configToRoute config.UpstreamConfig
 
-	for _, upstreamConfig := range r.upstreamConfigs {
-		if upstreamConfig.ID == upstreamID {
-			configToRoute = upstreamConfig
+	for idx := range r.upstreamConfigs {
+		if r.upstreamConfigs[idx].ID == upstreamID {
+			configToRoute = r.upstreamConfigs[idx]
 		}
 	}
 

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -112,7 +112,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
+	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{Method: "my_method"})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)
@@ -123,7 +123,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 		0: {&gethConfig},
 		1: {&erigonConfig},
 		2: {&openEthConfig, &somethingElseConfig},
-	}, metadata.RequestMetadata{})
+	}, metadata.RequestMetadata{Methods: []string{"my_method"}})
 	assert.Equal(t, "erigonURL", httpClientMock.Calls[0].Arguments[0].(*http.Request).URL.Path)
 }
 
@@ -158,7 +158,7 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
-	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{})
+	upstreamID, jsonRPCResp, httpResp, err := router.Route(context.Background(), &jsonrpc.SingleRequestBody{Method: "my_method"})
 	defer httpResp.Body.Close()
 
 	assert.Nil(t, err)
@@ -167,6 +167,6 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 	assert.Equal(t, "hello", jsonRPCResp.(*jsonrpc.SingleResponseBody).Result)
 	routingStrategyMock.AssertCalled(t, "RouteNextRequest", types.PriorityToUpstreamsMap{
 		0: {&gethConfig, &erigonConfig},
-	}, metadata.RequestMetadata{IsStateRequired: false})
+	}, metadata.RequestMetadata{Methods: []string{"my_method"}})
 	assert.Equal(t, "erigonURL", httpClientMock.Calls[0].Arguments[0].(*http.Request).URL.Path)
 }

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -32,7 +32,7 @@ func wireSingleChainDependencies(chainConfig *config.SingleChainConfig, logger *
 	ticker := time.NewTicker(checks.PeriodicHealthCheckInterval)
 	healthCheckManager := checks.NewHealthCheckManager(client.NewEthClient, chainConfig.Upstreams, chainMetadataStore, ticker, metricContainer, logger)
 
-	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.ArchiveNodeMethod, route.NearGlobalMaxHeight}
+	enabledNodeFilters := []route.NodeFilterType{route.Healthy, route.MaxHeightForGroup, route.MethodsAllowed, route.NearGlobalMaxHeight}
 	nodeFilter := route.CreateNodeFilter(enabledNodeFilters, healthCheckManager, chainMetadataStore, logger, &chainConfig.Routing)
 	routingStrategy := route.FilteringRoutingStrategy{
 		NodeFilter:      nodeFilter,


### PR DESCRIPTION
# Description

RFC: https://www.notion.so/satsuma-xyz/Mini-RFC-Node-Gateway-Method-based-routing-eedf6c5c29b048239dbfd7622ad297e2?d=8d04ff9cdd804a64b1c182d0ae650102#9a7a96d9c8d34f2ebbcb96569e7caa75

* Decided to strip out `isStateRequiredForMethod` and `IsTraceMethod` from `RequestMetadata ` and replace is with just plain method names (`Methods []string`). Then in the `node_filter` we check each method and compare with the `enabled|disabled` list as well as if the methods are archive or not.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# Release
* Test in staging before going to prod.
* The `eth_getLogs` -> archive logic is still here. I plan to remove it once we deploy this + update the node-gateway config to use the `method` config block to control this. Then, I'll send out a PR to remove the logic.

# How Has This Been Tested?
Config 1:
```
      - id: geth-eth-full-prod-1
        httpURL: "http://54.243.2.137:8545"
        group: primary
        nodeType: full
      - id: erigon-eth-archive-prod-3
        httpURL: "http://54.175.128.187:8545"
        group: primary
        nodeType: archive
```
Result:
```
curl --location --request POST 'localhost:8080/mainnet' \
--header 'Content-Type: application/json' \
--data-raw '{
        "jsonrpc":"2.0",
        "method":"eth_getBalance",
        "params":["0xf949ae357ab50212ccffad1af0b8e7a9bc1ee1497dafcaa4da56f7175cad3bfc", true],
        "id":1
}'

{"level":"debug","ts":"2023-01-25T10:56:23.390-0800","caller":"route/node_filter.go:222","msg":"Upstream method is archive, nodeType is not archive, and method has not been enabled! Skipping upstream.","chainName":"mainnet","UpstreamID":"geth-eth-full-prod-1","RequestMetadata":{"Methods":["eth_getBalance"]}}
```

Config 2:
```
      - id: geth-eth-full-prod-1
        httpURL: "http://54.243.2.137:8545"
        group: primary
        nodeType: full
        methods:
          enabled: eth_getBalance
      - id: erigon-eth-archive-prod-3
        httpURL: "http://54.175.128.187:8545"
        group: primary
        nodeType: archive
```

Result:
```
{"level":"debug","ts":"2023-01-25T11:00:22.833-0800","caller":"route/node_filter.go:36","msg":"Upstream passed all filters for request.","chainName":"mainnet","upstreamID":"geth-eth-full-prod-1","RequestMetadata":{"Methods":["eth_getBalance"]}}
{"level":"debug","ts":"2023-01-25T11:00:51.624-0800","caller":"route/request_executor.go:66","msg":"Successfully routed request to upstream.","chainName":"mainnet","upstreamID":"geth-eth-full-prod-1","request":{"id":1,"jsonrpc":"2.0","method":"eth_getBalance","params":["0xf949ae357ab50212ccffad1af0b8e7a9bc1ee1497dafcaa4da56f7175cad3bfc",true]},"response":{"error":{"message":"invalid argument 0: hex string has length 64, want 40 for common.Address","code":-32602},"jsonrpc":"2.0","id":1}}

Still gets routed to archive too
{"level":"debug","ts":"2023-01-25T11:01:07.437-0800","caller":"route/request_executor.go:66","msg":"Successfully routed request to upstream.","chainName":"mainnet","upstreamID":"erigon-eth-archive-prod-3","request":{"id":1,"jsonrpc":"2.0","method":"eth_getBalance","params":["0xf949ae357ab50212ccffad1af0b8e7a9bc1ee1497dafcaa4da56f7175cad3bfc",true]},"response":{"error":{"message":"invalid argument 0: hex string has length 64, want 40 for common.Address","code":-32602},"jsonrpc":"2.0","id":1}}
```

Config 3:
```
    upstreams:
      - id: geth-eth-full-prod-1
        httpURL: "http://54.243.2.137:8545"
        group: primary
        nodeType: full
        methods:
          enabled: eth_getBalance
      - id: erigon-eth-archive-prod-3
        httpURL: "http://54.175.128.187:8545"
        group: primary
        nodeType: archive
        methods:
          disabled: eth_getBalance
```


Result:
```
{"level":"debug","ts":"2023-01-25T11:02:22.670-0800","caller":"route/node_filter.go:210","msg":"Upstream method is disabled! Skipping upstream.","chainName":"mainnet","UpstreamID":"erigon-eth-archive-prod-3","RequestMetadata":{"Methods":["eth_getBalance"]}}
{"level":"debug","ts":"2023-01-25T11:02:22.670-0800","caller":"route/router.go:136","msg":"Routing request to upstream.","chainName":"mainnet","upstreamID":"geth-eth-full-prod-1","request":{"id":1,"jsonrpc":"2.0","method":"eth_getBalance","params":["0xf949ae357ab50212ccffad1af0b8e7a9bc1ee1497dafcaa4da56f7175cad3bfc",true]},"client":"unknown"}
```

