### PR TITLE
fix: remove eth_getLogs hardcode

### DIFF
--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -191,9 +191,6 @@ func isArchiveNodeMethod(method string) bool {
 	case "trace_filter", "trace_block", "trace_get", "trace_transaction", "trace_call", "trace_callMany",
 		"trace_rawTransaction", "trace_replayBlockTransactions", "trace_replayTransaction":
 		return true
-	case "eth_getLogs":
-		// Jan 25 2022 - Hack until we update configs to use the new `Methods` block.
-		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
# Description
We already have the new node-gateway-config in place already to disable `eth_getLogs` on specific full nodes (bor + geth). This hack is safe to remove.


## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)


