### PR TITLE
feat: option to skip peer count checks on an upstream

### DIFF
--- a/configs/config.sample.yml
+++ b/configs/config.sample.yml
@@ -42,6 +42,8 @@ chains:
       #     it quickly updates the gateway with the latest block height. If this
       #     setting is undefined, the gateway will attempt to subscribe to new
       #     heads if the upstream supports it.
+      #   skipPeerCountCheck - whether or not to skip the peer count check. Some chains,
+      #     like Optimism, always report a peer count of 0, so peer count can be ignored.
       # nodeType - full or archive
       - id: my-node
         httpURL: "http://12.57.207.168:8545"

--- a/internal/checks/peers.go
+++ b/internal/checks/peers.go
@@ -32,8 +32,9 @@ func NewPeerChecker(
 		clientGetter:     clientGetter,
 		metricsContainer: metricsContainer,
 		logger:           logger,
-		// Set `ShouldRun:true` until we verify `peerCount` is a supported method of the Upstream.
-		ShouldRun: true,
+		// When we verify `peerCount` is a supported method of the Upstream, this may be set
+		// to false if it's not supported.
+		ShouldRun: upstreamConfig.HealthCheckConfig.SkipPeerCountCheck == nil || !*upstreamConfig.HealthCheckConfig.SkipPeerCountCheck,
 	}
 
 	if err := c.Initialize(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,7 @@ func (c *UpstreamConfig) isValid(groups []GroupConfig) bool {
 type HealthCheckConfig struct {
 	// If not set - method to identify block height is auto-detected. Use websockets is its URL is set, else fall back to use HTTP polling.
 	UseWSForBlockHeight *bool `yaml:"useWsForBlockHeight"`
+	SkipPeerCountCheck  *bool `yaml:"skipPeerCountCheck"`
 }
 
 type BasicAuthConfig struct {


### PR DESCRIPTION
# Description

Optimism returns peer count of 0, so we need to skip the check to use Optimism nodes in the gateway.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Tested locally that we can route requests to optimism nodes with `skipPeerCountCheck: true`. 