### PR TITLE
chore: disable eth_syncing check

### DIFF
--- a/internal/route/node_filter.go
+++ b/internal/route/node_filter.go
@@ -262,13 +262,9 @@ func CreateSingleNodeFilter(
 			logger:             logger,
 			minimumPeerCount:   checks.MinimumPeerCount,
 		}
-		isDoneSyncing := IsDoneSyncing{
-			healthCheckManager: manager,
-			logger:             logger,
-		}
 
 		return &AndFilter{
-			filters: []NodeFilter{&hasEnoughPeers, &isDoneSyncing},
+			filters: []NodeFilter{&hasEnoughPeers},
 			logger:  logger,
 		}
 	case GlobalMaxHeight:


### PR DESCRIPTION
# Description

According to https://github.com/ethereum/go-ethereum/issues/25534, the `eth_syncing` check doesn't seem to reflect useful information for the node gateway:

> The eth_syncing is set to true by the downloader, when it downloads the N blocks it needs from peers. If you have fallen behind, that can be a pretty quick thing.
> Just because "a higher block exists somewhere", that doesn't mean eth_syncing becomes set to true. We look only at the local behaviour: are we in a sync-cycle?

We've had this check cause flakes lately where a node is within the block lag limit, but it returns "syncing" so we stop routing requests to it. Relying on block lag only appears to be more accurate.

Not deleting the relevant logic for now in case we decide we do want to re-enable it at some point in the near future.