### PR TITLE
fix: support null result in JSONRPC response

### DIFF
--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -60,10 +60,10 @@ type ResponseBody interface {
 
 // See: http://www.jsonrpc.org/specification#response_object
 type SingleResponseBody struct {
-	Result  any    `json:"result,omitempty"`
-	Error   *Error `json:"error,omitempty"`
-	JSONRPC string `json:"jsonrpc"`
-	ID      int64  `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *Error          `json:"error,omitempty"`
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
 }
 
 func (b *SingleResponseBody) Encode() ([]byte, error) {

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -60,9 +60,9 @@ type ResponseBody interface {
 
 // See: http://www.jsonrpc.org/specification#response_object
 type SingleResponseBody struct {
-	Result  json.RawMessage `json:"result,omitempty"`
 	Error   *Error          `json:"error,omitempty"`
 	JSONRPC string          `json:"jsonrpc"`
+	Result  json.RawMessage `json:"result,omitempty"`
 	ID      int64           `json:"id"`
 }
 

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -2,6 +2,7 @@ package jsonrpc
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"testing"
@@ -113,16 +114,16 @@ func TestEncodeAndDecodeResponses(t *testing.T) {
 	}{
 		{
 			testName: "single response",
-			body:     `{"result":"haha","jsonrpc":"2.0","id":67}`,
+			body:     `{"jsonrpc":"2.0","result":"haha","id":67}`,
 			expectedResponse: &SingleResponseBody{
-				Result:  []byte(`"haha"`),
+				Result:  json.RawMessage(`"haha"`),
 				JSONRPC: "2.0",
 				ID:      67,
 			},
 		},
 		{
 			testName: "null result",
-			body:     `{"result":null,"jsonrpc":"2.0","id":1}`,
+			body:     `{"jsonrpc":"2.0","result":null,"id":1}`,
 			expectedResponse: &SingleResponseBody{
 				Result:  []byte("null"),
 				JSONRPC: "2.0",
@@ -131,7 +132,7 @@ func TestEncodeAndDecodeResponses(t *testing.T) {
 		},
 		{
 			testName: "single response in batch",
-			body:     `[{"result":"haha","jsonrpc":"2.0","id":67}]`,
+			body:     `[{"jsonrpc":"2.0","result":"haha","id":67}]`,
 			expectedResponse: &BatchResponseBody{
 				Responses: []SingleResponseBody{
 					{
@@ -145,9 +146,9 @@ func TestEncodeAndDecodeResponses(t *testing.T) {
 		{
 			testName: "batch responses",
 			body: "[" +
-				`{"result":"haha","jsonrpc":"2.0","id":67},` +
-				`{"result":"something","jsonrpc":"2.0","id":68},` +
-				`{"result":"else","jsonrpc":"2.0","id":69}` +
+				`{"jsonrpc":"2.0","result":"haha","id":67},` +
+				`{"jsonrpc":"2.0","result":"something","id":68},` +
+				`{"jsonrpc":"2.0","result":"else","id":69}` +
 				"]",
 			expectedResponse: &BatchResponseBody{
 				Responses: []SingleResponseBody{

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -113,20 +113,29 @@ func TestEncodeAndDecodeResponses(t *testing.T) {
 	}{
 		{
 			testName: "single response",
-			body:     "{\"result\":\"haha\",\"jsonrpc\":\"2.0\",\"id\":67}",
+			body:     `{"result":"haha","jsonrpc":"2.0","id":67}`,
 			expectedResponse: &SingleResponseBody{
-				Result:  "haha",
+				Result:  []byte(`"haha"`),
 				JSONRPC: "2.0",
 				ID:      67,
 			},
 		},
 		{
+			testName: "null result",
+			body:     `{"result":null,"jsonrpc":"2.0","id":1}`,
+			expectedResponse: &SingleResponseBody{
+				Result:  []byte("null"),
+				JSONRPC: "2.0",
+				ID:      1,
+			},
+		},
+		{
 			testName: "single response in batch",
-			body:     "[{\"result\":\"haha\",\"jsonrpc\":\"2.0\",\"id\":67}]",
+			body:     `[{"result":"haha","jsonrpc":"2.0","id":67}]`,
 			expectedResponse: &BatchResponseBody{
 				Responses: []SingleResponseBody{
 					{
-						Result:  "haha",
+						Result:  []byte(`"haha"`),
 						JSONRPC: "2.0",
 						ID:      67,
 					},
@@ -136,24 +145,24 @@ func TestEncodeAndDecodeResponses(t *testing.T) {
 		{
 			testName: "batch responses",
 			body: "[" +
-				"{\"result\":\"haha\",\"jsonrpc\":\"2.0\",\"id\":67}," +
-				"{\"result\":\"something\",\"jsonrpc\":\"2.0\",\"id\":68}," +
-				"{\"result\":\"else\",\"jsonrpc\":\"2.0\",\"id\":69}" +
+				`{"result":"haha","jsonrpc":"2.0","id":67},` +
+				`{"result":"something","jsonrpc":"2.0","id":68},` +
+				`{"result":"else","jsonrpc":"2.0","id":69}` +
 				"]",
 			expectedResponse: &BatchResponseBody{
 				Responses: []SingleResponseBody{
 					{
-						Result:  "haha",
+						Result:  []byte(`"haha"`),
 						JSONRPC: "2.0",
 						ID:      67,
 					},
 					{
-						Result:  "something",
+						Result:  []byte(`"something"`),
 						JSONRPC: "2.0",
 						ID:      68,
 					},
 					{
-						Result:  "else",
+						Result:  []byte(`"else"`),
 						JSONRPC: "2.0",
 						ID:      69,
 					},

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -2,6 +2,7 @@ package route
 
 import (
 	"context"
+	"encoding/json"
 
 	"io"
 	"net/http"
@@ -118,7 +119,7 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, erigonConfig.ID, upstreamID)
 	assert.Equal(t, 203, httpResp.StatusCode)
-	assert.Equal(t, "hello", jsonRPCResp.(*jsonrpc.SingleResponseBody).Result)
+	assert.Equal(t, json.RawMessage(`"hello"`), jsonRPCResp.(*jsonrpc.SingleResponseBody).Result)
 	routingStrategyMock.AssertCalled(t, "RouteNextRequest", types.PriorityToUpstreamsMap{
 		0: {&gethConfig},
 		1: {&erigonConfig},
@@ -164,7 +165,7 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, erigonConfig.ID, upstreamID)
 	assert.Equal(t, 203, httpResp.StatusCode)
-	assert.Equal(t, "hello", jsonRPCResp.(*jsonrpc.SingleResponseBody).Result)
+	assert.Equal(t, json.RawMessage(`"hello"`), jsonRPCResp.(*jsonrpc.SingleResponseBody).Result)
 	routingStrategyMock.AssertCalled(t, "RouteNextRequest", types.PriorityToUpstreamsMap{
 		0: {&gethConfig, &erigonConfig},
 	}, metadata.RequestMetadata{Methods: []string{"my_method"}})

--- a/internal/server/web_server_test.go
+++ b/internal/server/web_server_test.go
@@ -23,7 +23,7 @@ func TestHandleJSONRPCRequest_Success(t *testing.T) {
 	router := mocks.NewRouter(t)
 	expectedRPCResponse := &jsonrpc.SingleResponseBody{
 		JSONRPC: jsonrpc.JSONRPCVersion,
-		Result:  "results",
+		Result:  json.RawMessage(`"results"`),
 		ID:      2,
 	}
 	router.EXPECT().Route(mock.Anything, mock.Anything).


### PR DESCRIPTION
# Description

We have seen several cases where the node-gateway responds to a graph-node with a missing `result` field. This results in an error message: `"failed to deserialize response: data did not match any variant of untagged enum Output"` that is difficult to debug. It also shows up in logs on customer subgraph dashboards, which leads to confusion for the end-user.

The main issue is that nodes will respond with `result` as null, which will get removed during unmarshaling due to the `omitempty` tag. In our case, we want to differentiate between an implicit null and an explicit null. We don't want the `result` field when it is not set(implicit), but we DO want `"result": null`(explicit). This setup is not easy to do out of the box with JSON tags. We also can't use the pointer trick because nil is still the zero value for pointers.

Couple approaches we can take here. First is customizing unmarshaling logic, which can get complex to maintain over time. Second approach is using the `json.RawMessage` type, which basically tells the marshal/unmarshal logic that we want the raw value. An explicit `null` value still gets past the unmarshal while an unset(implicit) value is handled properly by the omitempty tag.

Useful link describing the situation: https://www.calhoun.io/how-to-determine-if-a-json-key-has-been-set-to-null-or-not-provided/.
## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Found a request on the production node-gateway that is responding with the null result:
```
curl http://internal-node-gateway-production-862867910.us-east-1.elb.amazonaws.com/arbitrum-goerli \
>   -X POST \
>   -H "Content-Type: application/json" \
>   --data '{"method":"eth_getBlockByHash","params":["0x26c0d639fc37b27aa2594913c823f05d7e929db8d30b366ecb1075abbae7fae3",false],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1}
```

Double checked we would get the `"result": null` by directly hitting the full node in the config:
```
curl https://nd-762-998-322.p2pify.com/1c175b8875111c703eccb2de1b37921d \
>   -X POST \
>   -H "Content-Type: application/json" \
>   --data '{"method":"eth_getBlockByHash","params":["0x26c0d639fc37b27aa2594913c823f05d7e929db8d30b366ecb1075abbae7fae3",false],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":null}
```

Used this config locally with node-gateway to see what the response would be:
```
curl localhost:8080/arbitrum-goerli \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_getBlockByHash","params":["0x26c0d639fc37b27aa2594913c823f05d7e929db8d30b366ecb1075abbae7fae3",false],"id":1,"jsonrpc":"2.0"}'
{"result":null,"jsonrpc":"2.0","id":1}
```
