### PR TITLE
feat: Emit monitor_chains.latest_block_number metric

### DIFF
--- a/internal/checks/blockheight.go
+++ b/internal/checks/blockheight.go
@@ -119,6 +119,7 @@ func (c *BlockHeightCheck) runCheckHTTP() {
 		c.SetBlockHeight(header.Number.Uint64())
 
 		c.metricsContainer.BlockHeight.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Set(float64(c.blockHeight))
+		c.metricsContainer.ChainHeight.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Set(float64(c.blockHeight))
 
 		c.logger.Debug("Ran BlockHeightCheck over HTTP.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.String("httpURL", c.upstreamConfig.HTTPURL), zap.Uint64("blockHeight", c.blockHeight))
 	}
@@ -162,6 +163,7 @@ func (c *BlockHeightCheck) subscribeNewHead() error {
 
 		c.logger.Debug("Received blockheight over Websockets.", zap.Any("upstreamID", c.upstreamConfig.ID), zap.String("httpURL", c.upstreamConfig.HTTPURL), zap.Uint64("blockHeight", c.blockHeight))
 		c.metricsContainer.BlockHeight.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Set(float64(c.blockHeight))
+		c.metricsContainer.ChainHeight.WithLabelValues(c.upstreamConfig.ID, c.upstreamConfig.HTTPURL).Set(float64(c.blockHeight))
 
 		c.webSocketError = nil
 		c.setError(nil)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -136,8 +136,9 @@ var (
 	// because it's used in the other chain height monitoring system.
 	chainHeight = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "monitor_chains.latest_block_number",
-			Help: "Max height of a particular chain.",
+			Namespace: "monitor_chains",
+			Name:      "latest_block_number",
+			Help:      "Max height of a particular chain.",
 		},
 		[]string{"chain", "id", "url"},
 	)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -132,6 +132,16 @@ var (
 		[]string{"chain_name", "upstream_id", "url"},
 	)
 
+	// This format of this metric doesn't match other metrics here
+	// because it's used in the other chain height monitoring system.
+	chainHeight = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "monitor_chains.latest_block_number",
+			Help: "Max height of a particular chain.",
+		},
+		[]string{"chain", "id", "url"},
+	)
+
 	blockHeightCheckRequests = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metricsNamespace,
@@ -259,6 +269,7 @@ type Container struct {
 	UpstreamRPCDuration               prometheus.ObserverVec
 
 	BlockHeight              *prometheus.GaugeVec
+	ChainHeight              *prometheus.GaugeVec
 	BlockHeightCheckRequests *prometheus.CounterVec
 	BlockHeightCheckDuration prometheus.ObserverVec
 	BlockHeightCheckErrors   *prometheus.CounterVec
@@ -291,6 +302,11 @@ func NewContainer(chainName string) *Container {
 	result.RPCResponseSizes = rpcResponseSizes.MustCurryWith(presetLabels)
 
 	result.BlockHeight = blockHeight.MustCurryWith(presetLabels)
+	// This format of this metric differs since it must match the metric
+	// in the other chain height monitoring system.
+	result.ChainHeight = chainHeight.MustCurryWith(prometheus.Labels{
+		"chain": chainName,
+	})
 	result.BlockHeightCheckRequests = blockHeightCheckRequests.MustCurryWith(presetLabels)
 	result.BlockHeightCheckDuration = blockHeightCheckDuration.MustCurryWith(presetLabels)
 	result.BlockHeightCheckErrors = blockHeightCheckErrors.MustCurryWith(presetLabels)


### PR DESCRIPTION
# Description
- We've seen that sometimes the chain height returned from Ankr (or another RPC provider) goes backwards and causes our chain lag monitors to go off.
- Thus, we should also incorporate the block heights from our nodes into this monitor.
- However, I did not find a way to do this in Datadog, i.e. `max(metric1, metric2) - max(metric2)`. 
-  The `monitor_chains.latest_block_number` metric is currently emitted by the chain_height_monitoring [script](https://github.com/satsuma-xyz/satsuma/blob/b271fb2e95f31a2989744ed778c38423a04a2f0f/src/backend/jobs/chain_height_monitor.ts#L212) and used in the monitors.


Kinda ugly, open to suggestions!

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

*Please describe the tests that you ran to verify your changes.*
