### PR TITLE
fix: pass the max height in each group check if there is only one node

### DIFF
--- a/internal/route/filtering_strategy.go
+++ b/internal/route/filtering_strategy.go
@@ -33,7 +33,7 @@ func (s *FilteringRoutingStrategy) filter(
 		filteredUpstreams := make([]*config.UpstreamConfig, 0)
 
 		for _, upstreamConfig := range upstreamConfigs {
-			ok := s.NodeFilter.Apply(requestMetadata, upstreamConfig)
+			ok := s.NodeFilter.Apply(requestMetadata, upstreamConfig, len(upstreamConfigs))
 			if ok {
 				filteredUpstreams = append(filteredUpstreams, upstreamConfig)
 			}


### PR DESCRIPTION
# Description

If an upstream travels back in block height a bit, we won't route to it because we set the max height in each group across all checks instead of within 1 check. This is why requests arent getting routed to BSC blast even though it's the only node in a group and it's not lagging much.

It's not a complete fix since it doesn't handle multiple nodes in a PG, but doesn't introduce much tech debt and can work in conjunction with the actual fix to set block height in each group based on the most recent round of checks.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

*Please describe the tests that you ran to verify your changes.*
