### PR TITLE
Use json.Number to support both ints & strings IDs

### DIFF
--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -19,10 +19,10 @@ type RequestBody interface {
 
 // See: https://www.jsonrpc.org/specification#request_object
 type SingleRequestBody struct {
-	ID             *int64 `json:"id,omitempty"`
-	JSONRPCVersion string `json:"jsonrpc,omitempty"`
-	Method         string `json:"method,omitempty"`
-	Params         []any  `json:"params,omitempty"`
+	ID	       *json.Number `json:"id,omitempty"`
+	JSONRPCVersion string	    `json:"jsonrpc,omitempty"`
+	Method	       string	    `json:"method,omitempty"`
+	Params	       []any	    `json:"params,omitempty"`
 }
 
 func (b *SingleRequestBody) Encode() ([]byte, error) {
@@ -60,10 +60,10 @@ type ResponseBody interface {
 
 // See: http://www.jsonrpc.org/specification#response_object
 type SingleResponseBody struct {
-	Error   *Error          `json:"error,omitempty"`
-	JSONRPC string          `json:"jsonrpc"`
-	Result  json.RawMessage `json:"result,omitempty"`
-	ID      int64           `json:"id"`
+	Error	*Error		`json:"error,omitempty"`
+	JSONRPC string		`json:"jsonrpc"`
+	Result	json.RawMessage `json:"result,omitempty"`
+	ID	json.Number	`json:"id"`
 }
 
 func (b *SingleResponseBody) Encode() ([]byte, error) {
@@ -88,9 +88,9 @@ func (b *BatchResponseBody) GetSubResponses() []SingleResponseBody {
 
 // See: http://www.jsonrpc.org/specification#error_object
 type Error struct {
-	Data    any    `json:"data,omitempty"`
+	Data	any    `json:"data,omitempty"`
 	Message string `json:"message"`
-	Code    int    `json:"code"`
+	Code	int    `json:"code"`
 }
 
 type Decodable interface {
@@ -98,13 +98,13 @@ type Decodable interface {
 }
 
 type DecodeError struct {
-	Err     error
+	Err	error
 	Content []byte // Content that couldn't be decoded.
 }
 
 func NewDecodeError(err error, content []byte) DecodeError {
 	return DecodeError{
-		Err:     err,
+		Err:	 err,
 		Content: content,
 	}
 }
@@ -188,7 +188,7 @@ func CreateErrorJSONRPCResponseBody(message string, jsonRPCStatusCode int) *Sing
 	return &SingleResponseBody{
 		JSONRPC: JSONRPCVersion,
 		Error: &Error{
-			Code:    jsonRPCStatusCode,
+			Code:	 jsonRPCStatusCode,
 			Message: message,
 		},
 	}
@@ -211,7 +211,7 @@ func CreateErrorJSONRPCResponseBodyWithRequest(message string, jsonRPCStatusCode
 			response := SingleResponseBody{
 				JSONRPC: subReq.JSONRPCVersion,
 				Error: &Error{
-					Code:    jsonRPCStatusCode,
+					Code:	 jsonRPCStatusCode,
 					Message: message,
 				},
 				ID: *subReq.ID,

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/samber/lo"
@@ -14,48 +15,48 @@ import (
 func TestEncodeAndDecodeRequests(t *testing.T) {
 	for _, tc := range []struct {
 		expectedRequest RequestBody
-		testName        string
-		body            string
+		testName	string
+		body		string
 	}{
 		{
 			testName: "no ID",
-			body:     "{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}",
+			body:	  "{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}",
 			expectedRequest: &SingleRequestBody{
 				JSONRPCVersion: "2.0",
-				Method:         "web3_clientVersion",
-				Params:         []any{"hi"},
+				Method:		"web3_clientVersion",
+				Params:		[]any{"hi"},
 			},
 		},
 		{
 			testName: "ID zero",
-			body:     "{\"id\":0,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}",
+			body:	  "{\"id\":0,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}",
 			expectedRequest: &SingleRequestBody{
 				JSONRPCVersion: "2.0",
-				Method:         "web3_clientVersion",
-				Params:         []any{"hi"},
-				ID:             lo.ToPtr[int64](0),
+				Method:		"web3_clientVersion",
+				Params:		[]any{"hi"},
+				ID:		lo.ToPtr[json.Number](json.Number(strconv.Itoa(0))),
 			},
 		},
 		{
 			testName: "single request",
-			body:     "{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}",
+			body:	  "{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}",
 			expectedRequest: &SingleRequestBody{
 				JSONRPCVersion: "2.0",
-				Method:         "web3_clientVersion",
-				Params:         []any{"hi"},
-				ID:             lo.ToPtr[int64](67),
+				Method:		"web3_clientVersion",
+				Params:		[]any{"hi"},
+				ID:		lo.ToPtr[json.Number](json.Number(strconv.Itoa(67))),
 			},
 		},
 		{
 			testName: "single request in batch",
-			body:     "[{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}]",
+			body:	  "[{\"id\":67,\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\",\"params\":[\"hi\"]}]",
 			expectedRequest: &BatchRequestBody{
 				Requests: []SingleRequestBody{
 					{
 						JSONRPCVersion: "2.0",
-						Method:         "web3_clientVersion",
-						Params:         []any{"hi"},
-						ID:             lo.ToPtr[int64](67),
+						Method:		"web3_clientVersion",
+						Params:		[]any{"hi"},
+						ID:		lo.ToPtr[json.Number](json.Number(strconv.Itoa(67))),
 					},
 				},
 			},
@@ -71,21 +72,21 @@ func TestEncodeAndDecodeRequests(t *testing.T) {
 				Requests: []SingleRequestBody{
 					{
 						JSONRPCVersion: "2.0",
-						Method:         "web3_clientVersion",
-						Params:         []any{"hi"},
-						ID:             lo.ToPtr[int64](67),
+						Method:		"web3_clientVersion",
+						Params:		[]any{"hi"},
+				ID:		lo.ToPtr[json.Number](json.Number(strconv.Itoa(67))),
 					},
 					{
 						JSONRPCVersion: "2.0",
-						Method:         "web3_weee",
-						Params:         []any{"hi"},
-						ID:             lo.ToPtr[int64](68),
+						Method:		"web3_weee",
+						Params:		[]any{"hi"},
+				ID:		lo.ToPtr[json.Number](json.Number(strconv.Itoa(68))),
 					},
 					{
 						JSONRPCVersion: "2.0",
-						Method:         "web3_something_else",
-						Params:         []any{"hello"},
-						ID:             lo.ToPtr[int64](69),
+						Method:		"web3_something_else",
+						Params:		[]any{"hello"},
+				ID:		lo.ToPtr[json.Number](json.Number(strconv.Itoa(69))),
 					},
 				},
 			},
@@ -109,36 +110,36 @@ func TestEncodeAndDecodeRequests(t *testing.T) {
 func TestEncodeAndDecodeResponses(t *testing.T) {
 	for _, tc := range []struct {
 		expectedResponse ResponseBody
-		testName         string
-		body             string
+		testName	 string
+		body		 string
 	}{
 		{
 			testName: "single response",
-			body:     `{"jsonrpc":"2.0","result":"haha","id":67}`,
+			body:	  `{"jsonrpc":"2.0","result":"haha","id":67}`,
 			expectedResponse: &SingleResponseBody{
 				Result:  json.RawMessage(`"haha"`),
 				JSONRPC: "2.0",
-				ID:      67,
+				ID:	 json.Number(strconv.Itoa(67)),
 			},
 		},
 		{
 			testName: "null result",
-			body:     `{"jsonrpc":"2.0","result":null,"id":1}`,
+			body:	  `{"jsonrpc":"2.0","result":null,"id":1}`,
 			expectedResponse: &SingleResponseBody{
 				Result:  []byte("null"),
 				JSONRPC: "2.0",
-				ID:      1,
+				ID:	 json.Number(strconv.Itoa(1)),
 			},
 		},
 		{
 			testName: "single response in batch",
-			body:     `[{"jsonrpc":"2.0","result":"haha","id":67}]`,
+			body:	  `[{"jsonrpc":"2.0","result":"haha","id":67}]`,
 			expectedResponse: &BatchResponseBody{
 				Responses: []SingleResponseBody{
 					{
 						Result:  []byte(`"haha"`),
 						JSONRPC: "2.0",
-						ID:      67,
+						ID:	 json.Number(strconv.Itoa(67)),
 					},
 				},
 			},
@@ -155,17 +156,17 @@ func TestEncodeAndDecodeResponses(t *testing.T) {
 					{
 						Result:  []byte(`"haha"`),
 						JSONRPC: "2.0",
-						ID:      67,
+						ID:	 json.Number(strconv.Itoa(67)),
 					},
 					{
 						Result:  []byte(`"something"`),
 						JSONRPC: "2.0",
-						ID:      68,
+						ID:	 json.Number(strconv.Itoa(68)),
 					},
 					{
 						Result:  []byte(`"else"`),
 						JSONRPC: "2.0",
-						ID:      69,
+						ID:	 json.Number(strconv.Itoa(69)),
 					},
 				},
 			},

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -182,8 +182,12 @@ func (r *SimpleRouter) Route(
 			if req.ID == nil {
 				continue
 			}
+                        id, err := (*req.ID).Int64()
+                        if err != nil {
+				continue
+                        }
 
-			reqIDToRequestMap[*req.ID] = req
+			reqIDToRequestMap[id] = req
 		}
 
 		for _, resp := range body.GetSubResponses() {
@@ -193,7 +197,11 @@ func (r *SimpleRouter) Route(
 					zap.String("client", util.GetClientFromContext(ctx)), zap.String("upstreamID", upstreamID))
 
 				// In the rare case that the response has an ID that does not have a corresponding request.
-				if _, ok := reqIDToRequestMap[resp.ID]; !ok {
+                                id, err := resp.ID.Int64()
+                                if err != nil {
+                                        continue
+                                }
+				if _, ok := reqIDToRequestMap[id]; !ok {
 					continue
 				}
 
@@ -201,7 +209,7 @@ func (r *SimpleRouter) Route(
 					util.GetClientFromContext(ctx),
 					upstreamID,
 					configToRoute.HTTPURL,
-					reqIDToRequestMap[resp.ID].Method,
+					reqIDToRequestMap[id].Method,
 					HTTPReponseCode,
 					strconv.Itoa(resp.Error.Code),
 				).Inc()


### PR DESCRIPTION
# Description

ID numbers can be either an int or a string when being sent from clients. Node-gateway previously only accepted ints, but this can cause problems when using clients such as Metamask.

This change alters the type to be a number, which allows either to be accepted from clients. As a consequence, the gateway will always return only ints in response messages even if the client originally sent a string ID.

## Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Run on a private network against metamask, foundry, and other clients.
