### PR TITLE
Use method list

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"os"
-	"strings"
 
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
@@ -104,8 +103,8 @@ type MethodsConfig struct {
 
 func (m *MethodsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type MethodsConfigString struct {
-		Enabled  string
-		Disabled string
+		Enabled  []string
+		Disabled []string
 	}
 
 	var methodsConfigString MethodsConfigString
@@ -116,12 +115,12 @@ func (m *MethodsConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	m.Enabled = make(map[string]bool)
-	for _, method := range strings.Split(methodsConfigString.Enabled, ",") {
+	for _, method := range methodsConfigString.Enabled {
 		m.Enabled[method] = true
 	}
 
 	m.Disabled = make(map[string]bool)
-	for _, method := range strings.Split(methodsConfigString.Disabled, ",") {
+	for _, method := range methodsConfigString.Disabled {
 		m.Disabled[method] = true
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -203,8 +203,11 @@ func TestParseConfig_ValidConfig(t *testing.T) {
             group: primary
             nodeType: full
             methods:
-              enabled: eth_getStorageAt
-              disabled: eth_getBalance,getLogs
+              enabled:
+                - eth_getStorageAt
+              disabled:
+                - eth_getBalance
+                - getLogs
           - id: ankr-polygon
             httpURL: "https://rpc.ankr.com/polygon"
             wsURL: "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}"


### PR DESCRIPTION
# Description

Prior a string with a delimiter (`,`) was used for enabling and disabling methods. YAML has a built in list type, so this change enables the use of that.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [x] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Updated the unit tests, working against a private testnet.
