### PR TITLE
fix: handle null result in RPC response

### DIFF
--- a/configs/config.sample.yml
+++ b/configs/config.sample.yml
@@ -1,12 +1,16 @@
 global:
   port: 8080
   cache:
-    redis: kevin-test.jshtkz.ng.0001.use1.cache.amazonaws.com:6379
+    redis: redis-test.jshtkz.ng.0001.use1.cache.amazonaws.com:6379
 
 # List of supported chains.
 # The HTTP endpoint for a given chain is <host>:<port>/<chainName>.
 chains:
-  - chainName: ethereum
+  - chainName: mainnet
+    cache:
+      # Sets the ttl of set values in the cache.
+      # A ttl of zero will disable the cache.
+      ttl: 6s
     routing:
       # Number of blocks a node can be behind the max known height and
       # still get requests routed to it.

--- a/internal/cache/rpc_cache.go
+++ b/internal/cache/rpc_cache.go
@@ -14,8 +14,6 @@ import (
 
 var methodsToCache = []string{"eth_getTransactionReceipt"}
 
-const DefaultTTL = 30 * time.Minute
-
 type JSONRPCError struct {
 	err *jsonrpc.Error
 }
@@ -61,7 +59,7 @@ func (c *RPCCache) CreateRequestKey(chainName string, requestBody jsonrpc.Single
 	return fmt.Sprintf("%s:%s:%v", chainName, requestBody.Method, requestBody.Params)
 }
 
-func (c *RPCCache) HandleRequest(chainName string, reqBody jsonrpc.SingleRequestBody, originFunc func() (*jsonrpc.SingleResponseBody, error)) (json.RawMessage, error) {
+func (c *RPCCache) HandleRequest(chainName string, ttl time.Duration, reqBody jsonrpc.SingleRequestBody, originFunc func() (*jsonrpc.SingleResponseBody, error)) (json.RawMessage, error) {
 	var result json.RawMessage
 
 	// Even if the cache is down, redis-cache will route to the origin
@@ -71,7 +69,7 @@ func (c *RPCCache) HandleRequest(chainName string, reqBody jsonrpc.SingleRequest
 	err := c.Once(&cache.Item{
 		Key:   c.CreateRequestKey(chainName, reqBody),
 		Value: &result,
-		TTL:   DefaultTTL,
+		TTL:   ttl,
 		Do: func(*cache.Item) (interface{}, error) {
 			respBody, err := originFunc()
 			if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -13,6 +13,22 @@ func TestParseConfig_InvalidConfigs(t *testing.T) {
 		config string
 	}{
 		{
+			name: "Cache config has 0 < ttl < 1s",
+			config: `
+            global:
+              port: 8080
+
+            chains:
+              - chainName: ethereum
+                cache:
+                  ttl: 0.5s
+                upstreams:
+                  - id: alchemy-eth
+                    httpURL: "https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+                    nodeType: full
+            `,
+		},
+		{
 			name: "Upstream config without httpURL.",
 			config: `
             global:
@@ -164,15 +180,17 @@ func TestParseConfig_InvalidConfigs(t *testing.T) {
             `,
 		},
 	} {
-		configBytes := []byte(testCase.config)
-		_, err := parseConfig(configBytes)
-		assert.NotNil(t, err)
+		t.Run(testCase.name, func(t *testing.T) {
+			configBytes := []byte(testCase.config)
+			_, err := parseConfig(configBytes)
+			assert.NotNil(t, err)
 
-		// To prevent catching formatting errors, that's not what we're checking for in this test.
-		if err != nil {
-			assert.NotContains(t, err.Error(), "found character that cannot start any token", testCase.config)
-			assert.NotContains(t, err.Error(), "found a tab character that violates indentation", testCase.config)
-		}
+			// To prevent catching formatting errors, that's not what we're checking for in this test.
+			if err != nil {
+				assert.NotContains(t, err.Error(), "found character that cannot start any token", testCase.config)
+				assert.NotContains(t, err.Error(), "found a tab character that violates indentation", testCase.config)
+			}
+		})
 	}
 }
 

--- a/internal/route/router.go
+++ b/internal/route/router.go
@@ -38,17 +38,18 @@ type SimpleRouter struct {
 	chainMetadataStore *metadata.ChainMetadataStore
 	healthCheckManager checks.HealthCheckManager
 	routingStrategy    RoutingStrategy
-	requestExecutor    RequestExecutor
 	metricsContainer   *metrics.Container
 	logger             *zap.Logger
 	// Map from Priority => UpstreamIDs
 	priorityToUpstreams types.PriorityToUpstreamsMap
 	metadataParser      metadata.RequestMetadataParser
 	upstreamConfigs     []config.UpstreamConfig
+	requestExecutor     RequestExecutor
 }
 
 func NewRouter(
 	chainName string,
+	cacheConfig config.ChainCacheConfig,
 	upstreamConfigs []config.UpstreamConfig,
 	groupConfigs []config.GroupConfig,
 	chainMetadataStore *metadata.ChainMetadataStore,
@@ -64,7 +65,7 @@ func NewRouter(
 		upstreamConfigs:     upstreamConfigs,
 		priorityToUpstreams: groupUpstreamsByPriority(upstreamConfigs, groupConfigs),
 		routingStrategy:     routingStrategy,
-		requestExecutor:     RequestExecutor{&http.Client{}, logger, rpcCache, chainName},
+		requestExecutor:     RequestExecutor{&http.Client{}, logger, rpcCache, chainName, cacheConfig},
 		metadataParser:      metadata.RequestMetadataParser{},
 		metricsContainer:    metricsContainer,
 		logger:              logger,

--- a/internal/route/router_test.go
+++ b/internal/route/router_test.go
@@ -32,11 +32,12 @@ func TestRouter_NoHealthyUpstreams(t *testing.T) {
 			HTTPURL: "gethURL",
 		},
 	}
+	cacheConfig := config.ChainCacheConfig{}
 
 	routingStrategy := mocks.NewMockRoutingStrategy(t)
 	routingStrategy.EXPECT().RouteNextRequest(mock.Anything, mock.Anything).Return("", ErrNoHealthyUpstreams)
 
-	router := NewRouter("mainnet", upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, routingStrategy, metrics.NewContainer(config.TestChainName), zap.L(), nil)
+	router := NewRouter("mainnet", cacheConfig, upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, routingStrategy, metrics.NewContainer(config.TestChainName), zap.L(), nil)
 	router.(*SimpleRouter).healthCheckManager = managerMock
 	router.Start()
 
@@ -109,7 +110,9 @@ func TestRouter_GroupUpstreamsByPriority(t *testing.T) {
 			Priority: 2,
 		},
 	}
-	router := NewRouter("mainnet", upstreamConfigs, groupConfigs, metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer(config.TestChainName), zap.L(), nil)
+	cacheConfig := config.ChainCacheConfig{}
+
+	router := NewRouter("mainnet", cacheConfig, upstreamConfigs, groupConfigs, metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer(config.TestChainName), zap.L(), nil)
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 
@@ -154,8 +157,9 @@ func TestGroupUpstreamsByPriority_NoGroups(t *testing.T) {
 		gethConfig,
 		erigonConfig,
 	}
+	cacheConfig := config.ChainCacheConfig{}
 
-	router := NewRouter("mainnet", upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer(config.TestChainName), zap.L(), nil)
+	router := NewRouter("mainnet", cacheConfig, upstreamConfigs, make([]config.GroupConfig, 0), metadata.NewChainMetadataStore(), managerMock, nil, metrics.NewContainer(config.TestChainName), zap.L(), nil)
 	router.(*SimpleRouter).requestExecutor.httpClient = httpClientMock
 	router.(*SimpleRouter).routingStrategy = routingStrategyMock
 

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -41,7 +41,7 @@ func wireSingleChainDependencies(chainConfig *config.SingleChainConfig, logger *
 		Logger:          logger,
 	}
 
-	router := route.NewRouter(chainConfig.ChainName, chainConfig.Upstreams, chainConfig.Groups, chainMetadataStore, healthCheckManager, &routingStrategy, metricContainer, logger, rpcCache)
+	router := route.NewRouter(chainConfig.ChainName, chainConfig.Cache, chainConfig.Upstreams, chainConfig.Groups, chainMetadataStore, healthCheckManager, &routingStrategy, metricContainer, logger, rpcCache)
 
 	path := "/" + chainConfig.ChainName
 	handler := &RPCHandler{


### PR DESCRIPTION
# Description

RPC nodes will respond with `null` result in the JSON RPC response often times for new transaction hashes.  We should treat these similarly to JSON RPC responses that have `Error` field set, where the result is not cached and the response is sent back to the user without changes.  In these cases, the `graph-node` will automatically retry the request when it receives the response with the `null` result.

Technically, we could do some retries internally within `node-gateway` as well, but I think that logic is more complicated and the performance improvement is still unknown.  It would mainly save roundtrips between the indexers and node-gateway itself, which is less important than saving round trips from the node-gateway and RPC nodes.

## Type of change

- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Tested locally and on staging environment.