### PR TITLE
feat: add cached tag for request metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -71,18 +71,7 @@ var (
 			Help:      "Count of total RPC requests forwarded to upstreams.",
 		},
 		// jsonrpc_method is  "batch" for batch requests
-		[]string{"chain_name", "client", "upstream_id", "url", "jsonrpc_method"},
-	)
-
-	upstreamJSONRPCRequestsTotal = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsNamespace,
-			Subsystem: "router",
-			Name:      "upstream_jsonrpc_requests",
-			Help: "Count of total JSON RPC requests forwarded to upstreamsm including ones in batches. " +
-				"Batches are deconstructed to single JSON RPC requests for this metric.",
-		},
-		[]string{"chain_name", "client", "upstream_id", "url", "jsonrpc_method"},
+		[]string{"chain_name", "client", "upstream_id", "url", "jsonrpc_method", "cached"},
 	)
 
 	upstreamRPCRequestErrorsTotal = promauto.NewCounterVec(
@@ -93,7 +82,7 @@ var (
 			Help:      "Count of total errors when forwarding RPC requests to upstreams.",
 		},
 		// jsonrpc_method is "batch" for batch requests
-		[]string{"chain_name", "client", "upstream_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
+		[]string{"chain_name", "client", "upstream_id", "url", "jsonrpc_method", "response_code"},
 	)
 
 	upstreamJSONRPCRequestErrorsTotal = promauto.NewCounterVec(
@@ -117,7 +106,7 @@ var (
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 20, 40},
 		},
 		// jsonrpc_method is "batch" for batch requests
-		[]string{"chain_name", "client", "upstream_id", "url", "jsonrpc_method", "response_code", "jsonrpc_error_code"},
+		[]string{"chain_name", "client", "upstream_id", "url", "jsonrpc_method", "response_code"},
 	)
 
 	// Health check metrics
@@ -253,7 +242,6 @@ type Container struct {
 	RPCResponseSizes    prometheus.ObserverVec
 
 	UpstreamRPCRequestsTotal          *prometheus.CounterVec
-	UpstreamJSONRPCRequestsTotal      *prometheus.CounterVec
 	UpstreamRPCRequestErrorsTotal     *prometheus.CounterVec
 	UpstreamJSONRPCRequestErrorsTotal *prometheus.CounterVec
 	UpstreamRPCDuration               prometheus.ObserverVec
@@ -281,7 +269,6 @@ func NewContainer(chainName string) *Container {
 	}
 
 	result.UpstreamRPCRequestsTotal = upstreamRPCRequestsTotal.MustCurryWith(presetLabels)
-	result.UpstreamJSONRPCRequestsTotal = upstreamJSONRPCRequestsTotal.MustCurryWith(presetLabels)
 	result.UpstreamRPCRequestErrorsTotal = upstreamRPCRequestErrorsTotal.MustCurryWith(presetLabels)
 	result.UpstreamJSONRPCRequestErrorsTotal = upstreamJSONRPCRequestErrorsTotal.MustCurryWith(presetLabels)
 	result.UpstreamRPCDuration = upstreamRPCDuration.MustCurryWith(presetLabels)


### PR DESCRIPTION
# Description

Cleaned up some of the JSONRPC request metrics that are not used by dashboards right now. They have most of the same information as the corresponding upstream request metric. The only one that I could not remove as easily was the JSONRPC request error metric, which is more specific to the Error field in the JSON RPC response. This has a real use compared to the general upstream request error metric that measures non-200s.

The cached variable that is passed up to the metric does not exactly mean that it was a real cache hit to redis. The go-redis/cache library does not expose its internal cached state, so we can only try our best. If the Do() function is entered at all, we assume that the result was not cached. Otherwise, we assume that the result was cached. Technically, this means that even coalesced requests will be classified as cached as well. I think this is OK, since it means that there was no extra request to the origin.
## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Running locally.