### PR TITLE
chore: reduce peer check count to 3 peers

### DIFF
--- a/internal/checks/check.go
+++ b/internal/checks/check.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	JSONRPCErrCodeMethodNotFound = -32601
-	MinimumPeerCount             = 5
+	MinimumPeerCount             = 3
 	RPCRequestTimeout            = 10 * time.Second
 )
 

--- a/internal/checks/peers_test.go
+++ b/internal/checks/peers_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestPeerChecker(t *testing.T) {
 	ethClient := mocks.NewEthClient(t)
-	ethClient.EXPECT().PeerCount(mock.Anything).Return(uint64(6), nil)
+	ethClient.EXPECT().PeerCount(mock.Anything).Return(uint64(4), nil)
 
 	mockEthClientGetter := func(url string, credentials *client.BasicAuthCredentials) (client.EthClient, error) {
 		return ethClient, nil
@@ -27,7 +27,7 @@ func TestPeerChecker(t *testing.T) {
 	ethClient.AssertNumberOfCalls(t, "PeerCount", 1)
 
 	ethClient.ExpectedCalls = nil
-	ethClient.On("PeerCount", mock.Anything).Return(uint64(4), nil)
+	ethClient.On("PeerCount", mock.Anything).Return(uint64(2), nil)
 
 	checker.RunCheck()
 	assert.False(t, checker.IsPassing())
@@ -41,7 +41,7 @@ func TestPeerChecker(t *testing.T) {
 	ethClient.AssertNumberOfCalls(t, "PeerCount", 3)
 
 	ethClient.ExpectedCalls = nil
-	ethClient.On("PeerCount", mock.Anything).Return(uint64(6), nil)
+	ethClient.On("PeerCount", mock.Anything).Return(uint64(3), nil)
 
 	checker.RunCheck()
 	assert.True(t, checker.IsPassing())


### PR DESCRIPTION
# Description

When restarting polygon nodes, I noticed that it sometimes takes > 10 minutes to get to 5 peers. The node will sync with fewer peers. The upside of having the node available for usage earlier outweighs the downside of more peers (more trusted data).

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

*Please describe the tests that you ran to verify your changes.*
