### PR TITLE
feat: include additional request headers

### DIFF
--- a/configs/config.sample.yml
+++ b/configs/config.sample.yml
@@ -51,6 +51,7 @@ chains:
       #   skipPeerCountCheck - whether or not to skip the peer count check. Some chains,
       #     like Optimism, always report a peer count of 0, so peer count can be ignored.
       # nodeType - full or archive
+      # requestHeaders - Additional headers to add to the upstream request.
       - id: my-node
         httpURL: "http://12.57.207.168:8545"
         wsURL: "wss://12.57.207.168:8546"
@@ -73,3 +74,6 @@ chains:
           useWsForBlockHeight: false
         group: fallback
         nodeType: full
+        requestHeaders:
+          - key: "x-api-key"
+            value: "xxxx"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,14 +18,15 @@ const (
 )
 
 type UpstreamConfig struct {
-	Methods           MethodsConfig     `yaml:"methods"`
-	HealthCheckConfig HealthCheckConfig `yaml:"healthCheck"`
-	BasicAuthConfig   BasicAuthConfig   `yaml:"basicAuth"`
-	ID                string            `yaml:"id"`
-	HTTPURL           string            `yaml:"httpURL"`
-	WSURL             string            `yaml:"wsURL"`
-	GroupID           string            `yaml:"group"`
-	NodeType          NodeType          `yaml:"nodeType"`
+	Methods              MethodsConfig         `yaml:"methods"`
+	HealthCheckConfig    HealthCheckConfig     `yaml:"healthCheck"`
+	BasicAuthConfig      BasicAuthConfig       `yaml:"basicAuth"`
+	ID                   string                `yaml:"id"`
+	HTTPURL              string                `yaml:"httpURL"`
+	WSURL                string                `yaml:"wsURL"`
+	GroupID              string                `yaml:"group"`
+	NodeType             NodeType              `yaml:"nodeType"`
+	RequestHeadersConfig []RequestHeaderConfig `yaml:"requestHeaders"`
 }
 
 func (c *UpstreamConfig) isValid(groups []GroupConfig) bool {
@@ -96,6 +97,11 @@ type HealthCheckConfig struct {
 type BasicAuthConfig struct {
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
+}
+
+type RequestHeaderConfig struct {
+	Key   string `yaml:"key"`
+	Value string `yaml:"value"`
 }
 
 type MethodsConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -230,6 +230,11 @@ func TestParseConfig_ValidConfig(t *testing.T) {
             wsURL: "wss://rpc.ankr.com/polygon/ws/${ANKR_API_KEY}"
             group: fallback
             nodeType: archive
+            requestHeaders:
+              - key: "x-api-key"
+                value: "xxxx"
+              - key: "client-id"
+                value: "my-client"
 
       - chainName: polygon
         upstreams:
@@ -277,6 +282,16 @@ func TestParseConfig_ValidConfig(t *testing.T) {
 					},
 					GroupID:  "fallback",
 					NodeType: Archive,
+					RequestHeadersConfig: []RequestHeaderConfig{
+						{
+							Key:   "x-api-key",
+							Value: "xxxx",
+						},
+						{
+							Key:   "client-id",
+							Value: "my-client",
+						},
+					},
 				},
 			},
 			ChainName: "ethereum",

--- a/internal/route/request_executor.go
+++ b/internal/route/request_executor.go
@@ -61,6 +61,12 @@ func (r *RequestExecutor) routeToConfig(
 
 	httpReq.Header.Set("content-type", "application/json")
 
+	if configToRoute.RequestHeadersConfig != nil {
+		for _, headerConfig := range configToRoute.RequestHeadersConfig {
+			httpReq.Header.Set(headerConfig.Key, headerConfig.Value)
+		}
+	}
+
 	if configToRoute.BasicAuthConfig.Username != "" && configToRoute.BasicAuthConfig.Password != "" {
 		encodedCredentials := base64.StdEncoding.EncodeToString([]byte(configToRoute.BasicAuthConfig.Username + ":" + configToRoute.BasicAuthConfig.Password))
 		httpReq.Header.Set("Authorization", "Basic "+encodedCredentials)


### PR DESCRIPTION
# Description

This is needed to support Sky Mavis's Ronin JSON RPC endpoint, which requires a custom auth header. https://docs.skymavis.com/reference/ronin-json-rpc#using-with-web3js-and-ethersjs-library

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Testing locally to ensure we can route to requests when the `requestHeaders` config is present for ronin and absent for upstreams that don't require it.
