### PR TITLE
feat: record file descriptors used as a prom metric

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -53,7 +52,7 @@ func main() {
 
 	var rpcServer *server.RPCServer
 
-	var metricsServer *http.Server
+	var metricsServer *metrics.Server
 
 	zap.L().Info("Starting node gateway.", zap.String("env", env), zap.Any("config", conf))
 
@@ -71,7 +70,7 @@ func main() {
 	go func() {
 		metricsServer = metrics.NewMetricsServer()
 
-		if err := metricsServer.ListenAndServe(); err != http.ErrServerClosed {
+		if err := metricsServer.Start(); err != http.ErrServerClosed {
 			zap.L().Fatal("Failed to start metrics server.", zap.Error(err))
 		}
 	}()
@@ -90,7 +89,7 @@ func main() {
 		zap.L().Fatal("Failed to gracefully shut down RPC server.", zap.Error(err))
 	}
 
-	if err := metricsServer.Shutdown(context.Background()); err != nil {
+	if err := metricsServer.Shutdown(); err != nil {
 		zap.L().Fatal("Failed to gracefully shut down metrics server.", zap.Error(err))
 	}
 }


### PR DESCRIPTION
# Description
As title

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?
- Ran server locally 
- Verified metric is recorded and exposed properly in Prometheus. 
- Sanity check requests still work

Metrics:
```
➜  node-gateway git:(brianluong/track_file_descirptors) ✗ curl --silent localhost:9090/metrics | grep file_descriptors_used | grep -v '#'
node_gateway_file_descriptors_used 10
```

Request:
```
➜  node-gateway git:(main) ✗ curl --silent -k --request POST --url 'localhost:8080/blast-mainnet' --header 'accept: application/json' --header 'content-type: application/json' --data '
{
  "id": 1,
  "jsonrpc": "2.0",
  "method": "eth_getBlockByNumber",
  "params": [
                "latest",
    false
  ]
}'
{"jsonrpc":"2.0","result":{"baseFeePerGas":"0x97022","blobGasUsed":"0x0","difficulty":"0x0","excessBlobGas":"0x0","extraData":"0x","gasLimit...................
```