### PR TITLE
feat: high latency is no longer recorded if an error is

### DIFF
--- a/internal/checks/latency.go
+++ b/internal/checks/latency.go
@@ -148,10 +148,13 @@ func (c *LatencyCheck) IsPassing(methods []string) bool {
 	return true
 }
 
-func (c *LatencyCheck) RecordRequest(data *types.RequestData) {
+// RecordRequest records the request data for latency checking. It returns true if we recorded a high latency.
+func (c *LatencyCheck) RecordRequest(data *types.RequestData) bool {
 	if !c.isCheckEnabled {
-		return
+		return false
 	}
+
+	isHighLatency := false
 
 	// Record the request latency if latency checking is enabled.
 	if c.methodLatencyBreaker != nil {
@@ -165,6 +168,8 @@ func (c *LatencyCheck) RecordRequest(data *types.RequestData) {
 				metrics.HTTPRequest,
 				data.Method,
 			).Inc()
+
+			isHighLatency = true
 		}
 	}
 
@@ -173,4 +178,6 @@ func (c *LatencyCheck) RecordRequest(data *types.RequestData) {
 		c.upstreamConfig.HTTPURL,
 		data.Method,
 	).Set(float64(data.Latency.Milliseconds()))
+
+	return isHighLatency
 }

--- a/internal/checks/manager.go
+++ b/internal/checks/manager.go
@@ -133,8 +133,10 @@ func (h *healthCheckManager) GetLatencyCheck(upstreamID string) types.ErrorLaten
 }
 
 func (h *healthCheckManager) RecordRequest(upstreamID string, data *types.RequestData) {
-	h.GetUpstreamStatus(upstreamID).ErrorCheck.RecordRequest(data)
-	h.GetUpstreamStatus(upstreamID).LatencyCheck.RecordRequest(data)
+	isError := h.GetUpstreamStatus(upstreamID).ErrorCheck.RecordRequest(data)
+	if !isError {
+		h.GetUpstreamStatus(upstreamID).LatencyCheck.RecordRequest(data)
+	}
 }
 
 func (h *healthCheckManager) setUpstreamStatus(upstreamID string, status *types.UpstreamStatus) {

--- a/internal/mocks/ErrorLatencyChecker.go
+++ b/internal/mocks/ErrorLatencyChecker.go
@@ -67,8 +67,21 @@ func (_c *ErrorLatencyChecker_IsPassing_Call) RunAndReturn(run func([]string) bo
 }
 
 // RecordRequest provides a mock function with given fields: data
-func (_m *ErrorLatencyChecker) RecordRequest(data *types.RequestData) {
-	_m.Called(data)
+func (_m *ErrorLatencyChecker) RecordRequest(data *types.RequestData) bool {
+	ret := _m.Called(data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RecordRequest")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(*types.RequestData) bool); ok {
+		r0 = rf(data)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
 }
 
 // ErrorLatencyChecker_RecordRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecordRequest'
@@ -89,12 +102,12 @@ func (_c *ErrorLatencyChecker_RecordRequest_Call) Run(run func(data *types.Reque
 	return _c
 }
 
-func (_c *ErrorLatencyChecker_RecordRequest_Call) Return() *ErrorLatencyChecker_RecordRequest_Call {
-	_c.Call.Return()
+func (_c *ErrorLatencyChecker_RecordRequest_Call) Return(_a0 bool) *ErrorLatencyChecker_RecordRequest_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *ErrorLatencyChecker_RecordRequest_Call) RunAndReturn(run func(*types.RequestData)) *ErrorLatencyChecker_RecordRequest_Call {
+func (_c *ErrorLatencyChecker_RecordRequest_Call) RunAndReturn(run func(*types.RequestData) bool) *ErrorLatencyChecker_RecordRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -42,7 +42,7 @@ type Checker interface {
 //go:generate mockery --output ../mocks --name ErrorLatencyChecker --with-expecter
 type ErrorLatencyChecker interface {
 	IsPassing(methods []string) bool
-	RecordRequest(data *RequestData)
+	RecordRequest(data *RequestData) bool
 }
 
 type PriorityToUpstreamsMap map[int][]*config.UpstreamConfig


### PR DESCRIPTION
# Description

We no longer record high latency if an error was recorded for the same request.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

* Unit tests
* Integration tests
