### PR TITLE
feat: several improvements to Redis

### DIFF
--- a/internal/cache/rpc_cache.go
+++ b/internal/cache/rpc_cache.go
@@ -27,9 +27,6 @@ var redisWriteTimeout = 500 * time.Millisecond
 var localCacheSize = 1000
 var localCacheTTL = 10 * time.Second
 
-// var redisPoolTimeout = 100 * time.Millisecond
-// var redisPoolSize = runtime.NumCPU() * 30
-
 func CreateRedisReaderClient(url string) *redis.Client {
 	return createRedisClient(url, "reader")
 }
@@ -48,8 +45,6 @@ func createRedisClient(url, clientType string) *redis.Client {
 		DialTimeout:  redisDialTimeout,
 		ReadTimeout:  redisReadTimeout,
 		WriteTimeout: redisWriteTimeout,
-		// PoolTimeout:  redisPoolTimeout,
-		// PoolSize:     redisPoolSize,
 		OnConnect: func(_ context.Context, _ *redis.Conn) error {
 			zap.L().Info("established new connection to redis", zap.String("url", url))
 			metrics.CacheConnections.WithLabelValues(url).Inc()

--- a/internal/cache/rpc_cache.go
+++ b/internal/cache/rpc_cache.go
@@ -27,7 +27,15 @@ var redisWriteTimeout = 500 * time.Millisecond
 // var redisPoolTimeout = 100 * time.Millisecond
 // var redisPoolSize = runtime.NumCPU() * 30
 
-func CreateRedisClient(url string) *redis.Client {
+func CreateRedisReaderClient(url string) *redis.Client {
+	return createRedisClient(url, "reader")
+}
+
+func CreateRedisWriterClient(url string) *redis.Client {
+	return createRedisClient(url, "writer")
+}
+
+func createRedisClient(url, clientType string) *redis.Client {
 	if url == "" {
 		return nil
 	}
@@ -46,7 +54,10 @@ func CreateRedisClient(url string) *redis.Client {
 		},
 	})
 
-	collector := redisprometheus.NewCollector(metrics.MetricsNamespace, "redis_cache", rdb)
+	collector := redisprometheus.NewCollector(
+		metrics.MetricsNamespace,
+		fmt.Sprintf("redis_cache_%s", clientType),
+		rdb)
 	if err := prometheus.Register(collector); err != nil {
 		zap.L().Error("failed to register redis cache otel collector", zap.Error(err))
 	}

--- a/internal/cache/rpc_cache.go
+++ b/internal/cache/rpc_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -23,6 +24,7 @@ var redisDialTimeout = 2 * time.Second
 var redisReadTimeout = 500 * time.Millisecond
 var redisWriteTimeout = 500 * time.Millisecond
 var redisPoolTimeout = 100 * time.Millisecond
+var redisPoolSize = runtime.NumCPU() * 30
 
 func CreateRedisClient(url string) *redis.Client {
 	if url == "" {
@@ -35,6 +37,7 @@ func CreateRedisClient(url string) *redis.Client {
 		ReadTimeout:  redisReadTimeout,
 		WriteTimeout: redisWriteTimeout,
 		PoolTimeout:  redisPoolTimeout,
+		PoolSize:     redisPoolSize,
 	})
 
 	collector := redisprometheus.NewCollector(metrics.MetricsNamespace, "redis_cache", rdb)

--- a/internal/cache/rpc_cache.go
+++ b/internal/cache/rpc_cache.go
@@ -25,7 +25,7 @@ var redisReadTimeout = 500 * time.Millisecond
 var redisWriteTimeout = 500 * time.Millisecond
 
 var localCacheSize = 1000
-var localCacheTTL = 2 * time.Second
+var localCacheTTL = 10 * time.Second
 
 // var redisPoolTimeout = 100 * time.Millisecond
 // var redisPoolSize = runtime.NumCPU() * 30

--- a/internal/cache/rpc_cache.go
+++ b/internal/cache/rpc_cache.go
@@ -131,7 +131,7 @@ func (c *RPCCache) get(ctx context.Context, key, jsonRPCMethod string) (json.Raw
 
 func (c *RPCCache) set(ctx context.Context, key, jsonRPCMethod string, value json.RawMessage, ttl time.Duration) {
 	start := time.Now()
-	cmd := c.writeClient.Set(ctx, key, string(value), ttl)
+	cmd := c.writeClient.SetNX(ctx, key, string(value), ttl)
 	duration := time.Since(start)
 
 	err := cmd.Err()

--- a/internal/cache/rpc_cache.go
+++ b/internal/cache/rpc_cache.go
@@ -25,7 +25,7 @@ var redisReadTimeout = 500 * time.Millisecond
 var redisWriteTimeout = 500 * time.Millisecond
 
 var localCacheSize = 1000
-var localCacheTTL = 15 * time.Second
+var localCacheTTL = 2 * time.Second
 
 // var redisPoolTimeout = 100 * time.Millisecond
 // var redisPoolSize = runtime.NumCPU() * 30

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -363,6 +363,16 @@ var (
 		[]string{"chain_name", "operation"},
 	)
 
+	CacheConnections = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: MetricsNamespace,
+			Subsystem: "redis_cache",
+			Name:      "connections_total",
+			Help:      "Total number of Redis connections established",
+		},
+		[]string{"url"},
+	)
+
 	// System metrics
 	fileDescriptorsUsed = promauto.NewGauge(
 		prometheus.GaugeOpts{

--- a/internal/server/object_graph.go
+++ b/internal/server/object_graph.go
@@ -145,8 +145,8 @@ func WireDependenciesForAllChains(
 ) ObjectGraph {
 	readerAddr, writerAddr := gatewayConfig.Global.Cache.GetRedisAddresses()
 
-	redisReader := cache.CreateRedisClient(readerAddr)
-	redisWriter := cache.CreateRedisClient(writerAddr)
+	redisReader := cache.CreateRedisReaderClient(readerAddr)
+	redisWriter := cache.CreateRedisWriterClient(writerAddr)
 
 	singleChainDependencies := make([]singleChainObjectGraph, 0, len(gatewayConfig.Chains))
 	routers := make([]route.Router, 0, len(gatewayConfig.Chains))


### PR DESCRIPTION
# Description
- go back to using cache lib, but just use basic get/set commands (not the `Once` pipelining command). Main reason is there's a local cache implementation that I overlooked earlier, which can help us. The cache lib also implements a binary SerDe library which could make things faster.
- Use local cache
- Use `SetNX` (only set if key doesn’t exist) instead of `Set`
- metrics on Redis conns established - this is useful for debugging


## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?
Running in staging rn