### PR TITLE
chore: add instadefi ssl cert to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,13 @@ RUN make build-binary
 FROM docker.io/library/alpine:3.16
 
 RUN mkdir /satsuma
+
+RUN apk add --no-cache ca-certificates curl openssl
+RUN curl -s https://api-dev.instodefi.com | \
+    openssl s_client -connect api-dev.instodefi.com:443 -showcerts </dev/null | \
+    openssl x509 > /usr/local/share/ca-certificates/instodefi.crt && \
+    update-ca-certificates
+
 COPY --from=builder /app/build/bin/* /usr/local/bin
 
 EXPOSE 8080


### PR DESCRIPTION
# Description

Adding instadefi's SSL cert to the store so we can make rpc requests against their rpc.

## Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 😎 New feature (non-breaking change which adds functionality)
- [ ] ⁉️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚒️ Refactor (no functional changes)
- [ ] 📖 Documentation (updating or adding docs)

# How Has This Been Tested?

Tested running the commands on a docker image locally and then doing a curl to the new https endpoint.

```
➜  node-gateway git:(main) ✗ docker run -it --entrypoint /bin/sh 694773929020.dkr.ecr.us-east-1.amazonaws.com/node-gateway:0206d4e6a3f3a73ea9855585be14b02b72072374
Unable to find image '694773929020.dkr.ecr.us-east-1.amazonaws.com/node-gateway:0206d4e6a3f3a73ea9855585be14b02b72072374' locally
0206d4e6a3f3a73ea9855585be14b02b72072374: Pulling from node-gateway
550f8bf8502c: Pull complete
f526dc720ed7: Pull complete
6d685b842c63: Pull complete
Digest: sha256:c5ba4bc0a3292a1e9ff8be23aa13718270d0f2216663ab2efbdc6e4fc323471b
Status: Downloaded newer image for 694773929020.dkr.ecr.us-east-1.amazonaws.com/node-gateway:0206d4e6a3f3a73ea9855585be14b02b72072374
/ # RUN apk --no-cache add ca-certificates curl openssl
/bin/sh: RUN: not found
/ # apk --no-cache add ca-certificates curl openssl
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/aarch64/APKINDEX.tar.gz
(1/6) Installing ca-certificates (20240226-r0)
(2/6) Installing brotli-libs (1.0.9-r6)
(3/6) Installing nghttp2-libs (1.47.0-r2)
(4/6) Installing libcurl (8.5.0-r0)
(5/6) Installing curl (8.5.0-r0)
(6/6) Installing openssl (1.1.1w-r1)
Executing busybox-1.35.0-r17.trigger
Executing ca-certificates-20240226-r0.trigger
OK: 8 MiB in 20 packages
/ # curl -s https://api-dev.instodefi.com | \
>     openssl s_client -connect api-dev.instodefi.com:443 -showcerts </dev/null | \
>     openssl x509 > /usr/local/share/ca-certificates/instodefi.crt && \
>     update-ca-certificates
depth=0 C = AU, ST = Victoria, L = Docklands, O = Australia and New Zealand Banking Group Ltd, CN = api-dev.instodefi.com
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 C = AU, ST = Victoria, L = Docklands, O = Australia and New Zealand Banking Group Ltd, CN = api-dev.instodefi.com
verify error:num=21:unable to verify the first certificate
verify return:1
depth=0 C = AU, ST = Victoria, L = Docklands, O = Australia and New Zealand Banking Group Ltd, CN = api-dev.instodefi.com
verify return:1
DONE
/ # curl -X POST "https://api-dev.instodefi.com/anz-das-chain/rpc" \
>      -H "x-apikey: KKPzHQXe6gGrE3FpdvEGGOeABDE58fQtkMSQsqpvUQbZcqht" \
>      -H "Content-Type: application/json" \
>      -d '{
>           "jsonrpc": "2.0",
>           "method": "eth_getBlockByNumber",
>           "params": ["0x10d4f", true],
>           "id": 1
>      }'
{"jsonrpc":"2.0","id":1,"result":{"parentHash":"0x5be9c92e4d2219ba5e866415094cd07b4baeb0cb3195ff42605d5c685b0fb63b","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","miner":"0xec4517af3ad7dc1e96a5acccca66c1d31e738f9f","stateRoot":"0xd11ab63e805a80372e5c993077dcf7212af085ed242091a3379f49e99cbca1b5","transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","difficulty":"0x0","totalDifficulty":"0x0","size":"0x203","number":"0x10d4f","gasLimit":"0x4000000000000","gasUsed":"0x0","timestamp":"0x66c79a64","extraData":"0x","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","hash":"0x482ebc81889b7b411ff1b5b49ddd91a73f2684779eb38af7a135a376dfd808c8","transactions":[],"uncles":[]}}/
```

Also tested that hitting Alchemy front door RPC still works.

```
 # curl --location 'https://opt-mainnet.g.alchemy.com/v2/ropsten-demo' \
> --header 'Content-Type: application/json' \
> --data '{"id":1,"jsonrpc":"2.0","method":"alchemy_getAssetTransfers","params":[{"fromBlock":"0x0","toBlock":"latest","category":["external"],"contractAddre
sses":[],"order":"asc","withMetadata":true,"excludeZeroValue":false,"toAddress":"0xA219439258ca9da29E9Cc4cE5596924745e12B93"}]}'
{"jsonrpc":"2.0","id":1,"result":{"transfers":[{"blockNum":"0x6755957","uniqueId":"0x9da3118b92a7e1a4eda69dfe7e33a655782d7572dc504b0b94abc828ae4b10c2:external","hash":"0x9da3118b92a7e1a4eda69dfe7e33a655782d7572dc504b0b94abc828ae4b10c2","from":"0x40bd6e764dbc5c7268aac775d8978881b16221f1","to":"0xa219439258ca9da29e9cc4ce5596924745e12b93","value":0,"erc721TokenId":null,"erc1155Metadata":null,"tokenId":null,"asset":"ETH","category":"external","rawContract":{"value":"0x0","address":null,"decimal":"0x12"}...
```